### PR TITLE
EASY-1238: Update to latest ddm.xsd (2017) from easy-schema v1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,11 +25,11 @@
     </parent>
     <groupId>nl.knaw.dans.easy</groupId>
     <artifactId>ddm</artifactId>
-    <version>333.x-SNAPSHOT</version>
+    <version>3.x-SNAPSHOT</version>
     <name>Dans Dataset Metadata Library (DDM)</name>
     <inceptionYear>2014</inceptionYear>
     <properties>
-        <easy.schema.version>1.6</easy.schema.version>
+        <easy.schema.version>1.8</easy.schema.version>
     </properties>
     <scm>
         <developerConnection>scm:git:https://github.com/DANS-KNAW/${project.artifactId}</developerConnection>

--- a/src/main/java/nl/knaw/dans/pf/language/ddm/handlermaps/NameSpace.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/handlermaps/NameSpace.java
@@ -23,7 +23,7 @@ public enum NameSpace {
     GML("gml", "http://www.opengis.net/gml", "http://schemas.opengis.net/gml/3.2.1/gml.xsd"), //
     DCX_DAI("dcx-dai", "http://easy.dans.knaw.nl/schemas/dcx/dai/", "http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx-dai.xsd"), //
     DCX_GML("dcx-gml", "http://easy.dans.knaw.nl/schemas/dcx/gml/", "http://easy.dans.knaw.nl/schemas/dcx/2016/dcx-gml.xsd"), //
-    DDM("ddm", "http://easy.dans.knaw.nl/schemas/md/ddm/", "http://easy.dans.knaw.nl/schemas/md/2016/ddm.xsd"), //
+    DDM("ddm", "http://easy.dans.knaw.nl/schemas/md/ddm/", "http://easy.dans.knaw.nl/schemas/md/2017/ddm.xsd"), //
     XSI("xsi", "http://www.w3.org/2001/XMLSchema-instance", "https://www.w3.org/2001/XMLSchema-instance"), //
     NARCIS_TYPE("narcis", "http://easy.dans.knaw.nl/schemas/vocab/narcis-type/", "http://easy.dans.knaw.nl/schemas/vocab/2015/narcis-type.xsd"), //
     IDENTIFIER_TYPE("id-type", "http://easy.dans.knaw.nl/schemas/vocab/identifier-type/", "http://easy.dans.knaw.nl/schemas/vocab/2015/identifier-type.xsd"), //

--- a/src/test/java/nl/knaw/dans/pf/language/ddm/api/CrosswalkInlineTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/ddm/api/CrosswalkInlineTest.java
@@ -251,8 +251,8 @@ public class CrosswalkInlineTest {
         }
         final EasyMetadata emd = runTest(new Exception(), newRoot(newMiniProfile("") + newAdditional(sb.toString())), 0);
         logger.debug(Arrays.deepToString(emd.getEmdDate().getValues().toArray()));
-        // only the date from the default content of miniProfile is detected
-        assertThat(emd.getEmdDate().getValues().size(), is(1));
+        // only the dates from the default content of miniProfile are detected, ddm:created and ddm:available
+        assertThat(emd.getEmdDate().getValues().size(), is(2));
     }
 
     @Test
@@ -266,7 +266,7 @@ public class CrosswalkInlineTest {
     public void dates() throws Exception {
         final StringBuffer sb = new StringBuffer();
         // ddm:created is in miniProfile
-        sb.append(newEl("ddm:available", "", "1900"));
+        // ddm:available is in miniProfile
 
         int i = 0;
         for (final String field : dateFields) {
@@ -318,6 +318,7 @@ public class CrosswalkInlineTest {
                 + newEl("dcterms:description", "", "tv serie") //
                 + newEl("dc:creator", "", "meneer de uil") //
                 + newEl("ddm:created", "", "2013") //
+                + newEl("ddm:available", "", "2013") //
                 + newEl("ddm:audience", "", MINI_AUDIENCE) //
                 + newEl("ddm:accessRights", "", "OPEN_ACCESS_FOR_REGISTERED_USERS");
 

--- a/src/test/java/nl/knaw/dans/pf/language/ddm/api/CrosswalkInlineTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/ddm/api/CrosswalkInlineTest.java
@@ -318,7 +318,7 @@ public class CrosswalkInlineTest {
                 + newEl("dcterms:description", "", "tv serie") //
                 + newEl("dc:creator", "", "meneer de uil") //
                 + newEl("ddm:created", "", "2013") //
-                + newEl("ddm:available", "", "2013") //
+                + newEl("ddm:available", "", "2014") //
                 + newEl("ddm:audience", "", MINI_AUDIENCE) //
                 + newEl("ddm:accessRights", "", "OPEN_ACCESS_FOR_REGISTERED_USERS");
 
@@ -356,6 +356,7 @@ public class CrosswalkInlineTest {
         assertThat(emd.getEmdDescription().getDcDescription().get(0).getValue(), is("tv serie"));
         assertThat(emd.getEmdCreator().getDcCreator().get(0).getValue(), is("meneer de uil"));
         assertThat(emd.getEmdDate().getEasCreated().get(0).getValue(), is(new DateTime("2013")));
+        assertThat(emd.getEmdDate().getEasAvailable().get(0).getValue(), is(new DateTime("2014")));
         assertThat(emd.getEmdRights().getTermsAccessRights().get(0).getValue(), is("OPEN_ACCESS_FOR_REGISTERED_USERS"));
     }
 

--- a/src/test/resources/input/NameSpacePrefixVariants.xml
+++ b/src/test/resources/input/NameSpacePrefixVariants.xml
@@ -27,6 +27,7 @@
 		<xdcterms:description>tv serie</xdcterms:description>
 		<xdc:creator>meneer de uil</xdc:creator>
 		<xddm:created>2013</xddm:created>
+		<xddm:available>2013</xddm:available>
 		<xddm:audience>D41500</xddm:audience>
 		<xddm:accessRights>OPEN_ACCESS_FOR_REGISTERED_USERS</xddm:accessRights>
 	</xddm:profile>

--- a/src/test/resources/input/NameSpacePrefixVariants.xml
+++ b/src/test/resources/input/NameSpacePrefixVariants.xml
@@ -27,7 +27,7 @@
 		<xdcterms:description>tv serie</xdcterms:description>
 		<xdc:creator>meneer de uil</xdc:creator>
 		<xddm:created>2013</xddm:created>
-		<xddm:available>2013</xddm:available>
+		<xddm:available>2014</xddm:available>
 		<xddm:audience>D41500</xddm:audience>
 		<xddm:accessRights>OPEN_ACCESS_FOR_REGISTERED_USERS</xddm:accessRights>
 	</xddm:profile>

--- a/src/test/resources/input/abr.xml
+++ b/src/test/resources/input/abr.xml
@@ -34,7 +34,7 @@
 		<dcterms:description>tv serie</dcterms:description>
 		<dc:creator>meneer de uil</dc:creator>
 		<ddm:created>2013</ddm:created>
-		<ddm:available>2013</ddm:available>
+		<ddm:available>2014</ddm:available>
 		<ddm:audience>D41500</ddm:audience>
 		<ddm:accessRights>OPEN_ACCESS_FOR_REGISTERED_USERS</ddm:accessRights>
 	</ddm:profile>

--- a/src/test/resources/input/abr.xml
+++ b/src/test/resources/input/abr.xml
@@ -34,6 +34,7 @@
 		<dcterms:description>tv serie</dcterms:description>
 		<dc:creator>meneer de uil</dc:creator>
 		<ddm:created>2013</ddm:created>
+		<ddm:available>2013</ddm:available>
 		<ddm:audience>D41500</ddm:audience>
 		<ddm:accessRights>OPEN_ACCESS_FOR_REGISTERED_USERS</ddm:accessRights>
 	</ddm:profile>

--- a/src/test/resources/input/ddm-creators-organization-mixed.xml
+++ b/src/test/resources/input/ddm-creators-organization-mixed.xml
@@ -55,6 +55,7 @@
 			</dcx-dai:author>
 		</dcx-dai:creatorDetails>
 		<ddm:created>2013</ddm:created>
+		<ddm:available>2013</ddm:available>
 		<ddm:audience>D41500</ddm:audience>
 		<ddm:accessRights>OPEN_ACCESS_FOR_REGISTERED_USERS</ddm:accessRights>
 	</ddm:profile>

--- a/src/test/resources/input/ddm-with-doi.xml
+++ b/src/test/resources/input/ddm-with-doi.xml
@@ -40,8 +40,8 @@
                 </dcx-dai:organization>
             </dcx-dai:author>
         </dcx-dai:creatorDetails>
-		<ddm:created>2015-09-09</ddm:created>
-        <ddm:available>2015-09-09</ddm:available>
+	<ddm:created>2015-09-09</ddm:created>
+    <ddm:available>2015-09-09</ddm:available>
 	<ddm:audience>D41500</ddm:audience>
 	<ddm:accessRights>OPEN_ACCESS</ddm:accessRights>
 	</ddm:profile>

--- a/src/test/resources/input/ddm-with-doi.xml
+++ b/src/test/resources/input/ddm-with-doi.xml
@@ -40,9 +40,9 @@
                 </dcx-dai:organization>
             </dcx-dai:author>
         </dcx-dai:creatorDetails>
-	<ddm:created>2015-09-09</ddm:created>
+    <ddm:created>2015-09-09</ddm:created>
     <ddm:available>2015-09-09</ddm:available>
-	<ddm:audience>D41500</ddm:audience>
+    <ddm:audience>D41500</ddm:audience>
 	<ddm:accessRights>OPEN_ACCESS</ddm:accessRights>
 	</ddm:profile>
 	<ddm:dcmiMetadata>

--- a/src/test/resources/input/ddm-with-doi.xml
+++ b/src/test/resources/input/ddm-with-doi.xml
@@ -39,8 +39,9 @@
                     <dcx-dai:name xml:lang="en">DANS</dcx-dai:name>
                 </dcx-dai:organization>
             </dcx-dai:author>
-        </dcx-dai:creatorDetails>        
-        <ddm:created>2015-09-09</ddm:created>
+        </dcx-dai:creatorDetails>
+		<ddm:created>2015-09-09</ddm:created>
+        <ddm:available>2015-09-09</ddm:available>
 	<ddm:audience>D41500</ddm:audience>
 	<ddm:accessRights>OPEN_ACCESS</ddm:accessRights>
 	</ddm:profile>

--- a/src/test/resources/input/ddm.xml
+++ b/src/test/resources/input/ddm.xml
@@ -40,8 +40,8 @@
                 </dcx-dai:organization>
             </dcx-dai:author>
         </dcx-dai:creatorDetails>
-		<ddm:created>2015-09-09</ddm:created>
-        <ddm:available>2015-09-09</ddm:available>
+	<ddm:created>2015-09-09</ddm:created>
+    <ddm:available>2015-09-09</ddm:available>
 	<ddm:audience>D41500</ddm:audience>
 	<ddm:accessRights>OPEN_ACCESS</ddm:accessRights>
 	</ddm:profile>

--- a/src/test/resources/input/ddm.xml
+++ b/src/test/resources/input/ddm.xml
@@ -40,9 +40,9 @@
                 </dcx-dai:organization>
             </dcx-dai:author>
         </dcx-dai:creatorDetails>
-	<ddm:created>2015-09-09</ddm:created>
+    <ddm:created>2015-09-09</ddm:created>
     <ddm:available>2015-09-09</ddm:available>
-	<ddm:audience>D41500</ddm:audience>
+    <ddm:audience>D41500</ddm:audience>
 	<ddm:accessRights>OPEN_ACCESS</ddm:accessRights>
 	</ddm:profile>
 	<ddm:dcmiMetadata>

--- a/src/test/resources/input/ddm.xml
+++ b/src/test/resources/input/ddm.xml
@@ -39,8 +39,9 @@
                     <dcx-dai:name xml:lang="en">DANS</dcx-dai:name>
                 </dcx-dai:organization>
             </dcx-dai:author>
-        </dcx-dai:creatorDetails>        
-        <ddm:created>2015-09-09</ddm:created>
+        </dcx-dai:creatorDetails>
+		<ddm:created>2015-09-09</ddm:created>
+        <ddm:available>2015-09-09</ddm:available>
 	<ddm:audience>D41500</ddm:audience>
 	<ddm:accessRights>OPEN_ACCESS</ddm:accessRights>
 	</ddm:profile>

--- a/src/test/resources/input/spatial.xml
+++ b/src/test/resources/input/spatial.xml
@@ -30,7 +30,7 @@
 		<dcterms:description>tv serie</dcterms:description>
 		<dc:creator>meneer de uil</dc:creator>
 		<ddm:created>2013</ddm:created>
-		<ddm:available>2013</ddm:available>
+		<ddm:available>2014</ddm:available>
 		<ddm:audience>D41500</ddm:audience>
 		<ddm:accessRights>OPEN_ACCESS_FOR_REGISTERED_USERS</ddm:accessRights>
 	</ddm:profile>

--- a/src/test/resources/input/spatial.xml
+++ b/src/test/resources/input/spatial.xml
@@ -30,6 +30,7 @@
 		<dcterms:description>tv serie</dcterms:description>
 		<dc:creator>meneer de uil</dc:creator>
 		<ddm:created>2013</ddm:created>
+		<ddm:available>2013</ddm:available>
 		<ddm:audience>D41500</ddm:audience>
 		<ddm:accessRights>OPEN_ACCESS_FOR_REGISTERED_USERS</ddm:accessRights>
 	</ddm:profile>


### PR DESCRIPTION
fixes EASY-1238

#### When applied it will
* Add ddm:available to all ddm:profile in test-resources since it is required
* Update the pom to use easy-schema v1.8
* Update the pom to state 3.x-SNAPSHOT

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ---
easy-schema                      | [PR#30](https://github.com/DANS-KNAW/easy-schema/pull/30)     | 
