### PR TITLE
EASY-1257: DC_LANGUAGE / DC_FORMAT / DC_TYPE uitbreiden met xsi:type in DDM

### DIFF
--- a/src/main/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdHandlerMap.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdHandlerMap.java
@@ -314,9 +314,12 @@ public class Ddm2EmdHandlerMap implements CrosswalkHandlerMap<EasyMetadata> {
         map.put("/dcterms:description", descriptionHandler);
         // EasyMetadataImpl: EmdDescription emdDescription;
 
-        final BasicStringHandler dcFormatHandler = new DcFormatHandler();
+        final BasicStringHandler dcFormatHandler = new DcFormatHandler(false);
+        final BasicStringHandler imtFormatHandler = new DcFormatHandler(true);
         map.put("/dc:format", dcFormatHandler);
         map.put("/dcterms:format", dcFormatHandler);
+        map.put("IMT/dc:format", imtFormatHandler);
+        map.put("IMT/dcterms:format", imtFormatHandler);
         // <ref-panelId>dc.format.imt</ref-panelId>
         // <ref-panelId>dc.format</ref-panelId>
         // EasyMetadataImpl: EmdFormat emdFormat;
@@ -355,6 +358,8 @@ public class Ddm2EmdHandlerMap implements CrosswalkHandlerMap<EasyMetadata> {
         final BasicStringHandler dcTypeHandler = new DcTypeHandler();
         map.put("/dc:type", dcTypeHandler);
         map.put("/dcterms:type", dcTypeHandler);
+        map.put("DCMIType/dc:type", dcTypeHandler);
+        map.put("DCMIType/dcterms:type", dcTypeHandler);
         // <ref-panelId>dc.type</ref-panelId>
         // EasyMetadataImpl: EmdType emdType;
     }

--- a/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/DcFormatHandler.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/DcFormatHandler.java
@@ -21,10 +21,22 @@ import nl.knaw.dans.pf.language.emd.types.BasicString;
 import org.xml.sax.SAXException;
 
 public class DcFormatHandler extends BasicStringHandler {
+
+    private final boolean imt;
+
+    public DcFormatHandler(boolean imt) {
+        this.imt = imt;
+    }
+
     @Override
     protected void finishElement(final String uri, final String localName) throws SAXException {
         BasicString basicString = createBasicString(uri, localName);
-        if (basicString != null)
+        if (basicString != null) {
+            if (imt) {
+                basicString.setScheme("IMT");
+                basicString.setSchemeId("common.dc.format");
+            }
             getTarget().getEmdFormat().getDcFormat().add(basicString);
+        }
     }
 }

--- a/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/DcFormatHandler.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/DcFormatHandler.java
@@ -22,17 +22,17 @@ import org.xml.sax.SAXException;
 
 public class DcFormatHandler extends BasicStringHandler {
 
-    private final boolean imt;
+    private final boolean isInternetMediaType;
 
-    public DcFormatHandler(boolean imt) {
-        this.imt = imt;
+    public DcFormatHandler(boolean isInternetMediaType) {
+        this.isInternetMediaType = isInternetMediaType;
     }
 
     @Override
     protected void finishElement(final String uri, final String localName) throws SAXException {
         BasicString basicString = createBasicString(uri, localName);
         if (basicString != null) {
-            if (imt) {
+            if (isInternetMediaType) {
                 basicString.setScheme("IMT");
                 basicString.setSchemeId("common.dc.format");
             }

--- a/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/DcLanguageHandler.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/DcLanguageHandler.java
@@ -24,7 +24,10 @@ public class DcLanguageHandler extends BasicStringHandler {
     @Override
     protected void finishElement(final String uri, final String localName) throws SAXException {
         BasicString basicString = createBasicString(uri, localName);
-        if (basicString != null)
+        if (basicString != null) {
+            basicString.setScheme("ISO 639");
+            basicString.setSchemeId("common.dc.language");
             getTarget().getEmdLanguage().getDcLanguage().add(basicString);
+        }
     }
 }

--- a/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/DcTypeHandler.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/DcTypeHandler.java
@@ -24,7 +24,10 @@ public class DcTypeHandler extends BasicStringHandler {
     @Override
     protected void finishElement(final String uri, final String localName) throws SAXException {
         BasicString basicString = createBasicString(uri, localName);
-        if (basicString != null)
+        if (basicString != null) {
+            basicString.setScheme("DCMI");
+            basicString.setSchemeId("common.dc.type");
             getTarget().getEmdType().getDcType().add(basicString);
+        }
     }
 }

--- a/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
@@ -31,6 +31,96 @@ import static org.junit.Assert.assertThat;
 public class Ddm2EmdCrosswalkTest {
 
     @Test
+    public void formatWithSchemeAndId() throws Exception {
+        // @formatter:off
+        String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM"
+            + "  xmlns:dc='http://purl.org/dc/elements/1.1/'"
+            + "  xmlns:ddm='http://easy.dans.knaw.nl/schemas/md/ddm/'"
+            + "  xmlns:dcterms='http://purl.org/dc/terms/'"
+            + "  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>"
+            + "  <ddm:dcmiMetadata>"
+            + "    <dc:format xsi:type='dcterms:IMT'>text/plain</dc:format>"
+            + "    <dc:format>application/vnd.openxmlformats-officedocument.wordprocessingml.document</dc:format>"
+            + "  </ddm:dcmiMetadata>"
+            + "</ddm:DDM>";
+        // @formatter:on
+
+        DefaultElement top = firstEmdElementFrom(ddm);
+        assertThat(top.elements().size(), is(2));
+        assertThat(top.getQualifiedName(), is("emd:format"));
+
+        DefaultElement sub1 = (DefaultElement) top.elements().get(0);
+        assertThat(sub1.getQualifiedName(), is("dc:format"));
+        assertThat(sub1.getText(), is("text/plain"));
+        assertThat(sub1.attributeCount(), is(2));
+        assertThat(sub1.attribute("scheme").getQualifiedName(), is("eas:scheme"));
+        assertThat(sub1.attribute("scheme").getValue(), is("IMT"));
+        assertThat(sub1.attribute("schemeId").getQualifiedName(), is("eas:schemeId"));
+        assertThat(sub1.attribute("schemeId").getValue(), is("common.dc.format"));
+
+        DefaultElement sub = (DefaultElement) top.elements().get(1);
+        assertThat(sub.getQualifiedName(), is("dc:format"));
+        assertThat(sub.getText(), is("application/vnd.openxmlformats-officedocument.wordprocessingml.document"));
+        assertThat(sub.attributeCount(), is(0));
+    }
+
+    @Test
+    public void typeWithSchemeAndId() throws Exception {
+        // @formatter:off
+        String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM"
+            + "  xmlns:dc='http://purl.org/dc/elements/1.1/'"
+            + "  xmlns:ddm='http://easy.dans.knaw.nl/schemas/md/ddm/'"
+            + "  xmlns:dcterms='http://purl.org/dc/terms/'"
+            + "  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>"
+            + "  <ddm:dcmiMetadata>"
+            + "    <dcterms:type xsi:type='dcterms:DCMIType'>Text</dcterms:type>"
+            + "  </ddm:dcmiMetadata>"
+            + "</ddm:DDM>";
+        // @formatter:on
+
+        DefaultElement top = firstEmdElementFrom(ddm);
+        assertThat(top.elements().size(), is(1));
+        assertThat(top.getQualifiedName(), is("emd:type"));
+
+        DefaultElement sub = (DefaultElement) top.elements().get(0);
+        assertThat(sub.getQualifiedName(), is("dc:type"));
+        assertThat(sub.getText(), is("Text"));
+        assertThat(sub.attributeCount(), is(2));
+        assertThat(sub.attribute("scheme").getQualifiedName(), is("eas:scheme"));
+        assertThat(sub.attribute("scheme").getValue(), is("DCMI"));
+        assertThat(sub.attribute("schemeId").getQualifiedName(), is("eas:schemeId"));
+        assertThat(sub.attribute("schemeId").getValue(), is("common.dc.type"));
+    }
+
+    @Test
+    public void languageWithSchemeAndId() throws Exception {
+        // @formatter:off
+        String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM"
+            + "  xmlns:dc='http://purl.org/dc/elements/1.1/'"
+            + "  xmlns:ddm='http://easy.dans.knaw.nl/schemas/md/ddm/'"
+            + "  xmlns:dcterms='http://purl.org/dc/terms/'"
+            + "  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>"
+            + "  <ddm:dcmiMetadata>"
+            + "    <dc:language xsi:type='dcterms:ISO639-2'>nld</dc:language>"
+            + "  </ddm:dcmiMetadata>"
+            + "</ddm:DDM>";
+        // @formatter:on
+
+        DefaultElement top = firstEmdElementFrom(ddm);
+        assertThat(top.elements().size(), is(1));
+        assertThat(top.getQualifiedName(), is("emd:language"));
+
+        DefaultElement sub = (DefaultElement) top.elements().get(0);
+        assertThat(sub.getQualifiedName(), is("dc:language"));
+        assertThat(sub.getText(), is("nld"));
+        assertThat(sub.attributeCount(), is(2));
+        assertThat(sub.attribute("scheme").getQualifiedName(), is("eas:scheme"));
+        assertThat(sub.attribute("scheme").getValue(), is("ISO 639"));
+        assertThat(sub.attribute("schemeId").getQualifiedName(), is("eas:schemeId"));
+        assertThat(sub.attribute("schemeId").getValue(), is("common.dc.language"));
+    }
+
+    @Test
     public void spatialGmlEnvelope() throws Exception {
         // @formatter:off
         String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM" +

--- a/src/test/java/nl/knaw/dans/pf/language/nl/knaw/dans/pf/language/ddm/handlermaps/NameSpaceTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/nl/knaw/dans/pf/language/ddm/handlermaps/NameSpaceTest.java
@@ -34,7 +34,7 @@ public class NameSpaceTest {
                 String localPath = RECENT_SCHEMAS.get(name).toString();
                 String expectedRelativePath = localPath.replace(LOCAL_SCHEMA_DIR, "");
                 String implementedRelativePath = ns.xsd.replace("http://easy.dans.knaw.nl/schemas/", "");
-                assertThat("latset xsd for NameSpace " + ns, implementedRelativePath, is(expectedRelativePath));
+                assertThat("latest xsd for NameSpace " + ns, implementedRelativePath, is(expectedRelativePath));
             }
         }
     }


### PR DESCRIPTION
fixes EASY-1257

#### When applied it will
* transform the xsi:type to the correct `scheme`/`schemeId` attributes in the EMD
* add corresponding tests
* fix a typo

@DANS-KNAW/easy for review

#### related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ---
easy-split-multi-deposit                      | [PR#67](https://github.com/DANS-KNAW/easy-split-multi-deposit/pull/67)     | 
