### PR TITLE
EASY-1258: add DC_IDENTIFIER_TYPE

### DIFF
--- a/src/main/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdHandlerMap.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdHandlerMap.java
@@ -48,7 +48,6 @@ import nl.knaw.dans.pf.language.ddm.handlers.DcSourceHandler;
 import nl.knaw.dans.pf.language.ddm.handlers.DcTypeHandler;
 import nl.knaw.dans.pf.language.ddm.handlers.DescriptionHandler;
 import nl.knaw.dans.pf.language.ddm.handlers.EasSpatialHandler;
-import nl.knaw.dans.pf.language.ddm.handlers.IdentifierHandler;
 import nl.knaw.dans.pf.language.ddm.handlers.SimpleContributorHandler;
 import nl.knaw.dans.pf.language.ddm.handlers.SimpleCreatorHandler;
 import nl.knaw.dans.pf.language.ddm.handlers.SkippedFieldHandler;
@@ -57,6 +56,8 @@ import nl.knaw.dans.pf.language.ddm.handlers.TermsRightsHolderHandler;
 import nl.knaw.dans.pf.language.ddm.handlers.TermsSpatialHandler;
 import nl.knaw.dans.pf.language.ddm.handlers.TermsTemporalHandler;
 import nl.knaw.dans.pf.language.ddm.handlers.TitleHandler;
+import nl.knaw.dans.pf.language.ddm.handlers.ArchisIdentifierHandler;
+import nl.knaw.dans.pf.language.ddm.handlers.IdentifierHandler;
 import nl.knaw.dans.pf.language.ddm.handlertypes.BasicDateHandler;
 import nl.knaw.dans.pf.language.ddm.handlertypes.BasicIdentifierHandler;
 import nl.knaw.dans.pf.language.ddm.handlertypes.BasicStringHandler;
@@ -123,7 +124,7 @@ public class Ddm2EmdHandlerMap implements CrosswalkHandlerMap<EasyMetadata> {
             putAudienceHandlers();
             putAuthorHandlers();
             putDateHandlers();
-            putRalationHandlers();
+            putRelationHandlers();
             putAboutHandlers();
             putMiscellaneousHandlers();
 
@@ -197,7 +198,7 @@ public class Ddm2EmdHandlerMap implements CrosswalkHandlerMap<EasyMetadata> {
         map.put("/dcx-dai:contributor", new DaiContributorHandler());
     }
 
-    private void putRalationHandlers() {
+    private void putRelationHandlers() {
         final BasicIdentifierHandler dcRelationHandler = new DcRelationHandler();
         map.put("/ddm:relation", dcRelationHandler);
         map.put("/dc:relation", dcRelationHandler);
@@ -329,8 +330,20 @@ public class Ddm2EmdHandlerMap implements CrosswalkHandlerMap<EasyMetadata> {
         // EasyMetadataImpl: EmdOther emdOther;
 
         final BasicIdentifierHandler identifierHandler = new IdentifierHandler();
+        final BasicIdentifierHandler isbnIdentifierHandler = new IdentifierHandler("ISBN");
+        final BasicIdentifierHandler issnIdentifierHandler = new IdentifierHandler("ISSN");
+        final BasicIdentifierHandler nwoIdentifierHandler = new IdentifierHandler("NWO-projectnummer");
+        final BasicIdentifierHandler archisIdentifierHandler = new ArchisIdentifierHandler();
         map.put("/dc:identifier", identifierHandler);
         map.put("/dcterms:identifier", identifierHandler);
+        map.put("ISBN/dc:identifier", isbnIdentifierHandler);
+        map.put("ISBN/dcterms:identifier", isbnIdentifierHandler);
+        map.put("ISSN/dc:identifier", issnIdentifierHandler);
+        map.put("ISSN/dcterms:identifier", issnIdentifierHandler);
+        map.put("NWO-PROJECTNR/dc:identifier", nwoIdentifierHandler);
+        map.put("NWO-PROJECTNR/dcterms:identifier", nwoIdentifierHandler);
+        map.put("ARCHIS-ZAAK-IDENTIFICATIE/dc:identifier", archisIdentifierHandler);
+        map.put("ARCHIS-ZAAK-IDENTIFICATIE/dcterms:identifier", archisIdentifierHandler);
         // <ref-panelId>dc.identifier</ref-panelId>
         // EasyMetadataImpl: EmdIdentifier emdIdentifier;
         // Not supported By DDM:

--- a/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/ArchisIdentifierHandler.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/ArchisIdentifierHandler.java
@@ -1,0 +1,36 @@
+package nl.knaw.dans.pf.language.ddm.handlers;
+
+import nl.knaw.dans.pf.language.emd.types.BasicIdentifier;
+import org.xml.sax.SAXException;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class ArchisIdentifierHandler extends IdentifierHandler {
+
+  public ArchisIdentifierHandler() {
+    super("Archis_onderzoek_m_nr");
+  }
+
+  @Override protected void setScheme(BasicIdentifier identifier) throws SAXException {
+    super.setScheme(identifier);
+
+    identifier.setSchemeId("archaeology.dc.identifier");
+
+    try {
+      String value = identifier.getValue();
+      if (value.length() < 10) {
+        identifier.setIdentificationSystem(new URI("http://archis2.archis.nl"));
+      }
+      else if (value.length() == 10) {
+        identifier.setIdentificationSystem(new URI("https://archis.cultureelerfgoed.nl"));
+      }
+      else {
+        throw new SAXException("identifier '" + value + "' should have 10 or less characters");
+      }
+    }
+    catch (URISyntaxException e) {
+      throw new SAXException(e);
+    }
+  }
+}

--- a/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/ArchisIdentifierHandler.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/ArchisIdentifierHandler.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2014 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.pf.language.ddm.handlers;
 
 import nl.knaw.dans.pf.language.emd.types.BasicIdentifier;
@@ -8,29 +23,28 @@ import java.net.URISyntaxException;
 
 public class ArchisIdentifierHandler extends IdentifierHandler {
 
-  public ArchisIdentifierHandler() {
-    super("Archis_onderzoek_m_nr");
-  }
-
-  @Override protected void setScheme(BasicIdentifier identifier) throws SAXException {
-    super.setScheme(identifier);
-
-    identifier.setSchemeId("archaeology.dc.identifier");
-
-    try {
-      String value = identifier.getValue();
-      if (value.length() < 10) {
-        identifier.setIdentificationSystem(new URI("http://archis2.archis.nl"));
-      }
-      else if (value.length() == 10) {
-        identifier.setIdentificationSystem(new URI("https://archis.cultureelerfgoed.nl"));
-      }
-      else {
-        throw new SAXException("identifier '" + value + "' should have 10 or less characters");
-      }
+    public ArchisIdentifierHandler() {
+        super("Archis_onderzoek_m_nr");
     }
-    catch (URISyntaxException e) {
-      throw new SAXException(e);
+
+    @Override
+    protected void setScheme(BasicIdentifier identifier) throws SAXException {
+        super.setScheme(identifier);
+
+        identifier.setSchemeId("archaeology.dc.identifier");
+
+        try {
+            String value = identifier.getValue();
+            if (value.length() < 10) {
+                identifier.setIdentificationSystem(new URI("http://archis2.archis.nl"));
+            } else if (value.length() == 10) {
+                identifier.setIdentificationSystem(new URI("https://archis.cultureelerfgoed.nl"));
+            } else {
+                throw new SAXException("identifier '" + value + "' should have 10 or less characters");
+            }
+        }
+        catch (URISyntaxException e) {
+            throw new SAXException(e);
+        }
     }
-  }
 }

--- a/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/IdentifierHandler.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/IdentifierHandler.java
@@ -15,16 +15,33 @@
  */
 package nl.knaw.dans.pf.language.ddm.handlers;
 
-import org.xml.sax.SAXException;
-
 import nl.knaw.dans.pf.language.ddm.handlertypes.BasicIdentifierHandler;
 import nl.knaw.dans.pf.language.emd.types.BasicIdentifier;
+import org.xml.sax.SAXException;
 
 public class IdentifierHandler extends BasicIdentifierHandler {
+
+    private final String scheme;
+
+    public IdentifierHandler() {
+        this(null);
+    }
+
+    public IdentifierHandler(String scheme) {
+        this.scheme = scheme;
+    }
+
     @Override
     public void finishElement(final String uri, final String localName) throws SAXException {
         final BasicIdentifier identifier = createIdentifier(uri, localName);
-        if (identifier != null)
+        if (identifier != null) {
+            this.setScheme(identifier);
             getTarget().getEmdIdentifier().add(identifier);
+        }
+    }
+
+    protected void setScheme(BasicIdentifier identifier) throws SAXException {
+        if (scheme != null)
+            identifier.setScheme(scheme);
     }
 }

--- a/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
@@ -31,6 +31,170 @@ import static org.junit.Assert.assertThat;
 public class Ddm2EmdCrosswalkTest {
 
     @Test
+    public void identifierWithIdTypeISBN() throws Exception {
+        // @formatter:off
+        String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM"
+            + "  xmlns:dc='http://purl.org/dc/elements/1.1/'"
+            + "  xmlns:ddm='http://easy.dans.knaw.nl/schemas/md/ddm/'"
+            + "  xmlns:dcterms='http://purl.org/dc/terms/'"
+            + "  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>"
+            + "  <ddm:dcmiMetadata>"
+            + "    <dc:identifier xsi:type='id-type:ISBN'>123456</dc:identifier>"
+            + "  </ddm:dcmiMetadata>"
+            + "</ddm:DDM>";
+        // @formatter:on
+
+        DefaultElement top = firstEmdElementFrom(ddm);
+        assertThat(top.elements().size(), is(1));
+        assertThat(top.getQualifiedName(), is("emd:identifier"));
+
+        DefaultElement sub = (DefaultElement) top.elements().get(0);
+        assertThat(sub.getQualifiedName(), is("dc:identifier"));
+        assertThat(sub.getText(), is("123456"));
+        assertThat(sub.attributeCount(), is(1));
+        assertThat(sub.attribute("scheme").getQualifiedName(), is("eas:scheme"));
+        assertThat(sub.attribute("scheme").getValue(), is("ISBN"));
+    }
+
+    @Test
+    public void identifierWithIdTypeISSN() throws Exception {
+        // @formatter:off
+        String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM"
+            + "  xmlns:dc='http://purl.org/dc/elements/1.1/'"
+            + "  xmlns:ddm='http://easy.dans.knaw.nl/schemas/md/ddm/'"
+            + "  xmlns:dcterms='http://purl.org/dc/terms/'"
+            + "  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>"
+            + "  <ddm:dcmiMetadata>"
+            + "    <dc:identifier xsi:type='id-type:ISSN'>123456</dc:identifier>"
+            + "  </ddm:dcmiMetadata>"
+            + "</ddm:DDM>";
+        // @formatter:on
+
+        DefaultElement top = firstEmdElementFrom(ddm);
+        assertThat(top.elements().size(), is(1));
+        assertThat(top.getQualifiedName(), is("emd:identifier"));
+
+        DefaultElement sub = (DefaultElement) top.elements().get(0);
+        assertThat(sub.getQualifiedName(), is("dc:identifier"));
+        assertThat(sub.getText(), is("123456"));
+        assertThat(sub.attributeCount(), is(1));
+        assertThat(sub.attribute("scheme").getQualifiedName(), is("eas:scheme"));
+        assertThat(sub.attribute("scheme").getValue(), is("ISSN"));
+    }
+
+    @Test
+    public void identifierWithIdTypeNwoProjectNummer() throws Exception {
+        // @formatter:off
+        String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM"
+            + "  xmlns:dc='http://purl.org/dc/elements/1.1/'"
+            + "  xmlns:ddm='http://easy.dans.knaw.nl/schemas/md/ddm/'"
+            + "  xmlns:dcterms='http://purl.org/dc/terms/'"
+            + "  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>"
+            + "  <ddm:dcmiMetadata>"
+            + "    <dc:identifier xsi:type='id-type:NWO-PROJECTNR'>123456</dc:identifier>"
+            + "  </ddm:dcmiMetadata>"
+            + "</ddm:DDM>";
+        // @formatter:on
+
+        DefaultElement top = firstEmdElementFrom(ddm);
+        assertThat(top.elements().size(), is(1));
+        assertThat(top.getQualifiedName(), is("emd:identifier"));
+
+        DefaultElement sub = (DefaultElement) top.elements().get(0);
+        assertThat(sub.getQualifiedName(), is("dc:identifier"));
+        assertThat(sub.getText(), is("123456"));
+        assertThat(sub.attributeCount(), is(1));
+        assertThat(sub.attribute("scheme").getQualifiedName(), is("eas:scheme"));
+        assertThat(sub.attribute("scheme").getValue(), is("NWO-projectnummer"));
+    }
+
+    @Test
+    public void identifierWithIdTypeOldArchis() throws Exception {
+        // new archis number if it has less than 10 digits
+        // @formatter:off
+        String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM"
+            + "  xmlns:dc='http://purl.org/dc/elements/1.1/'"
+            + "  xmlns:ddm='http://easy.dans.knaw.nl/schemas/md/ddm/'"
+            + "  xmlns:dcterms='http://purl.org/dc/terms/'"
+            + "  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>"
+            + "  <ddm:dcmiMetadata>"
+            + "    <dc:identifier xsi:type='id-type:ARCHIS-ZAAK-IDENTIFICATIE'>123456789</dc:identifier>"
+            + "  </ddm:dcmiMetadata>"
+            + "</ddm:DDM>";
+        // @formatter:on
+
+        DefaultElement top = firstEmdElementFrom(ddm);
+        assertThat(top.elements().size(), is(1));
+        assertThat(top.getQualifiedName(), is("emd:identifier"));
+
+        DefaultElement sub = (DefaultElement) top.elements().get(0);
+        assertThat(sub.getQualifiedName(), is("dc:identifier"));
+        assertThat(sub.getText(), is("123456789"));
+        assertThat(sub.attributeCount(), is(3));
+        assertThat(sub.attribute("scheme").getQualifiedName(), is("eas:scheme"));
+        assertThat(sub.attribute("scheme").getValue(), is("Archis_onderzoek_m_nr"));
+        assertThat(sub.attribute("schemeId").getQualifiedName(), is("eas:schemeId"));
+        assertThat(sub.attribute("schemeId").getValue(), is("archaeology.dc.identifier"));
+        assertThat(sub.attribute("identification-system").getQualifiedName(), is("eas:identification-system"));
+        assertThat(sub.attribute("identification-system").getValue(), is("http://archis2.archis.nl"));
+    }
+
+    @Test
+    public void identifierWithIdTypeNewArchis() throws Exception {
+        // new archis number if it has exactly 10 digits
+        // @formatter:off
+        String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM"
+            + "  xmlns:dc='http://purl.org/dc/elements/1.1/'"
+            + "  xmlns:ddm='http://easy.dans.knaw.nl/schemas/md/ddm/'"
+            + "  xmlns:dcterms='http://purl.org/dc/terms/'"
+            + "  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>"
+            + "  <ddm:dcmiMetadata>"
+            + "    <dc:identifier xsi:type='id-type:ARCHIS-ZAAK-IDENTIFICATIE'>0123456789</dc:identifier>"
+            + "  </ddm:dcmiMetadata>"
+            + "</ddm:DDM>";
+        // @formatter:on
+
+        DefaultElement top = firstEmdElementFrom(ddm);
+        assertThat(top.elements().size(), is(1));
+        assertThat(top.getQualifiedName(), is("emd:identifier"));
+
+        DefaultElement sub = (DefaultElement) top.elements().get(0);
+        assertThat(sub.getQualifiedName(), is("dc:identifier"));
+        assertThat(sub.getText(), is("0123456789"));
+        assertThat(sub.attributeCount(), is(3));
+        assertThat(sub.attribute("scheme").getQualifiedName(), is("eas:scheme"));
+        assertThat(sub.attribute("scheme").getValue(), is("Archis_onderzoek_m_nr"));
+        assertThat(sub.attribute("schemeId").getQualifiedName(), is("eas:schemeId"));
+        assertThat(sub.attribute("schemeId").getValue(), is("archaeology.dc.identifier"));
+        assertThat(sub.attribute("identification-system").getQualifiedName(), is("eas:identification-system"));
+        assertThat(sub.attribute("identification-system").getValue(), is("https://archis.cultureelerfgoed.nl"));
+    }
+
+    @Test
+    public void identifierWithoutIdType() throws Exception {
+        // @formatter:off
+        String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM"
+            + "  xmlns:dc='http://purl.org/dc/elements/1.1/'"
+            + "  xmlns:ddm='http://easy.dans.knaw.nl/schemas/md/ddm/'"
+            + "  xmlns:dcterms='http://purl.org/dc/terms/'"
+            + "  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>"
+            + "  <ddm:dcmiMetadata>"
+            + "    <dc:identifier>ds1</dc:identifier>"
+            + "  </ddm:dcmiMetadata>"
+            + "</ddm:DDM>";
+        // @formatter:on
+
+        DefaultElement top = firstEmdElementFrom(ddm);
+        assertThat(top.elements().size(), is(1));
+        assertThat(top.getQualifiedName(), is("emd:identifier"));
+
+        DefaultElement sub = (DefaultElement) top.elements().get(0);
+        assertThat(sub.getQualifiedName(), is("dc:identifier"));
+        assertThat(sub.getText(), is("ds1"));
+        assertThat(sub.attributeCount(), is(0));
+    }
+
+    @Test
     public void formatWithSchemeAndId() throws Exception {
         // @formatter:off
         String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM"


### PR DESCRIPTION
fixes EASY-1258

#### When applied it will
* add crosswalker handlers for identifiers with `xsi:type`
* add tests accordingly
* fix a typo (thanks to @lindareijnhoudt)

@DANS-KNAW/easy for review

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-schema                      | [PR#31](https://github.com/DANS-KNAW/easy-schema/pull/31)
easy-split-multi-deposit | [PR#69](https://github.com/DANS-KNAW/easy-split-multi-deposit/pull/69)
