### PR TITLE
Easy 1280

### DIFF
--- a/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/DcLanguageHandler.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/DcLanguageHandler.java
@@ -25,9 +25,28 @@ public class DcLanguageHandler extends BasicStringHandler {
     protected void finishElement(final String uri, final String localName) throws SAXException {
         BasicString basicString = createBasicString(uri, localName);
         if (basicString != null) {
-            basicString.setScheme("ISO 639");
-            basicString.setSchemeId("common.dc.language");
+            String emdLanguageCode = getEmdLanguageCode(basicString.getValue());
+            if (emdLanguageCode != null) {
+                basicString.setValue(emdLanguageCode);
+                basicString.setScheme("ISO 639");
+                basicString.setSchemeId("common.dc.language");
+            }
             getTarget().getEmdLanguage().getDcLanguage().add(basicString);
         }
+    }
+
+    private String getEmdLanguageCode(final String language) {
+        String code = null;
+
+        if ("dut".equals(language) || "nld".equals(language))
+            code = "dut/nld";
+        else if ("deu".equals(language) || "ger".equals(language))
+            code = "ger/deu";
+        else if ("fra".equals(language) || "fre".equals(language))
+            code = "fre/fra";
+        else if ("eng".equals(language))
+            code = "eng";
+
+        return code;
     }
 }

--- a/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
@@ -257,7 +257,7 @@ public class Ddm2EmdCrosswalkTest {
     }
 
     @Test
-    public void languageWithSchemeAndId() throws Exception {
+    public void languageWithSchemeAndIdToEmdCode() throws Exception {
         // @formatter:off
         String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM"
             + "  xmlns:dc='http://purl.org/dc/elements/1.1/'"
@@ -282,6 +282,30 @@ public class Ddm2EmdCrosswalkTest {
         assertThat(sub.attribute("scheme").getValue(), is("ISO 639"));
         assertThat(sub.attribute("schemeId").getQualifiedName(), is("eas:schemeId"));
         assertThat(sub.attribute("schemeId").getValue(), is("common.dc.language"));
+    }
+
+    @Test
+    public void languageWithSchemeAndIdButNoEmdCode() throws Exception {
+        // @formatter:off
+        String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM"
+            + "  xmlns:dc='http://purl.org/dc/elements/1.1/'"
+            + "  xmlns:ddm='http://easy.dans.knaw.nl/schemas/md/ddm/'"
+            + "  xmlns:dcterms='http://purl.org/dc/terms/'"
+            + "  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>"
+            + "  <ddm:dcmiMetadata>"
+            + "    <dc:language xsi:type='dcterms:ISO639-2'>gre</dc:language>"
+            + "  </ddm:dcmiMetadata>"
+            + "</ddm:DDM>";
+        // @formatter:on
+
+        DefaultElement top = firstEmdElementFrom(ddm);
+        assertThat(top.elements().size(), is(1));
+        assertThat(top.getQualifiedName(), is("emd:language"));
+
+        DefaultElement sub = (DefaultElement) top.elements().get(0);
+        assertThat(sub.getQualifiedName(), is("dc:language"));
+        assertThat(sub.getText(), is("gre"));
+        assertThat(sub.attributeCount(), is(0));
     }
 
     @Test

--- a/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
@@ -276,7 +276,7 @@ public class Ddm2EmdCrosswalkTest {
 
         DefaultElement sub = (DefaultElement) top.elements().get(0);
         assertThat(sub.getQualifiedName(), is("dc:language"));
-        assertThat(sub.getText(), is("nld"));
+        assertThat(sub.getText(), is("dut/nld"));
         assertThat(sub.attributeCount(), is(2));
         assertThat(sub.attribute("scheme").getQualifiedName(), is("eas:scheme"));
         assertThat(sub.attribute("scheme").getValue(), is("ISO 639"));

--- a/src/test/resources/output/example2.xml
+++ b/src/test/resources/output/example2.xml
@@ -97,12 +97,12 @@
         <dc:source>nog een bron</dc:source>
     </emd:source>
     <emd:language>
-        <dc:language eas:scheme="ISO 639" eas:schemeId="common.dc.language">Nederlands</dc:language>
-        <dc:language eas:scheme="ISO 639" eas:schemeId="common.dc.language">Engels</dc:language>
-        <dc:language eas:scheme="ISO 639" eas:schemeId="common.dc.language">Ned</dc:language>
-        <dc:language eas:scheme="ISO 639" eas:schemeId="common.dc.language">en</dc:language>
-        <dc:language eas:scheme="ISO 639" eas:schemeId="common.dc.language">Dui</dc:language>
-        <dc:language eas:scheme="ISO 639" eas:schemeId="common.dc.language">fr</dc:language>
+        <dc:language>Nederlands</dc:language>
+        <dc:language>Engels</dc:language>
+        <dc:language>Ned</dc:language>
+        <dc:language>en</dc:language>
+        <dc:language>Dui</dc:language>
+        <dc:language>fr</dc:language>
     </emd:language>
     <emd:relation>
         <dc:relation eas:schemeId="STREAMING_SURROGATE_RELATION">/domain/dans/user/somebody/collection/test1/presentation/testA</dc:relation>


### PR DESCRIPTION
fixes EASY-1280 - ISO639-2 language is not properly handled by Sword2 deposits

#### When applied it will
* map the language codes received in DDM to EMD codes that EASY can use. Only the four main languages (English, French, German and Dutch) are mapped to dc:language with scheme="ISO 639", others are mapped to plain dc:language. 

#### Where should the reviewer @DANS-KNAW/easy start?
src/main/java/nl/knaw/dans/pf/language/ddm/handlers/DcLanguageHandler.java

#### How should this be manually tested?
Deposit a bag with in the DDM: 
`<dc:language xsi:type="dcterms:ISO639-2">nld</dc:language>
`This should result in a dataset with the following in  the EMD: 
`<dc:language eas:scheme="ISO 639" eas:schemeId="common.dc.language">dut/nld</dc:language>`

Note that you need to build the easy-ddm first, then rebuild easy-stage-dataset with this SNAPSHOT version, so change the pom first. Then rebuild easy-ingest-flow and redeploy it. 
If you have upgraded the server in this way, you can do the sword2 deposit with the easy-sword2-dans-examples client application. 


#### related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ---
easy-                      | [PR#](PRlink)     | 