### PR TITLE
EASY-1323: Repair the attribute for the STREAMING-SURROGATE-RELATION

### DIFF
--- a/src/main/java/nl/knaw/dans/pf/language/ddm/relationhandlers/DcRelationHandler.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/relationhandlers/DcRelationHandler.java
@@ -23,9 +23,9 @@ public class DcRelationHandler extends BasicStringHandler {
     @Override
     public void finishElement(final String uri, final String localName) throws SAXException {
         final BasicString relation = createBasicString(uri, localName);
-        final String schemeId = getAttribute("", "scheme");
-        if (schemeId != null)
-            relation.setSchemeId(schemeId);
+        final String scheme = getAttribute("", "scheme");
+        if (scheme != null)
+            relation.setScheme(scheme);
         if (relation != null)
             getTarget().getEmdRelation().getDcRelation().add(relation);
     }

--- a/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
@@ -543,6 +543,34 @@ public class Ddm2EmdCrosswalkTest {
         assertThat(sub.attribute("scheme").getValue(), is("ABR"));
     }
 
+    @Test
+    public void streamingSurrogateRelation() throws Exception {
+        // @formatter:off
+        String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM" +
+                "  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'" +
+                "  xmlns:ddm='http://easy.dans.knaw.nl/schemas/md/ddm/'" +
+                "  xmlns:dc='http://purl.org/dc/elements/1.1/'" +
+                "  xmlns:abr='http://www.den.nl/standaard/166/Archeologisch-Basisregister/'" +
+                ">" +
+                " <ddm:dcmiMetadata>" +
+                "  <ddm:relation scheme='STREAMING_SURROGATE_RELATION'>presentation</ddm:relation> "+
+                " </ddm:dcmiMetadata>" +
+                "</ddm:DDM>";
+        // @formatter:on
+
+        DefaultElement top = firstEmdElementFrom(ddm);
+
+        DefaultElement sub = (DefaultElement) top.elements().get(0);
+
+        assertThat(top.elements().size(), is(1));
+        assertThat(top.getQualifiedName(), is("emd:relation"));
+        assertThat(sub.getQualifiedName(), is("dc:relation"));
+        assertThat(sub.getText(), is("presentation"));
+        assertThat(sub.attributeCount(), is(1));
+        assertThat(sub.attribute("scheme").getQualifiedName(), is("eas:scheme"));
+        assertThat(sub.attribute("scheme").getValue(), is("STREAMING_SURROGATE_RELATION"));
+    }
+
     private DefaultElement firstEmdElementFrom(String ddm) throws XMLSerializationException, CrosswalkException {
         EasyMetadata emd = new Ddm2EmdCrosswalk(null).createFrom(ddm);
         return (DefaultElement) new EmdMarshaller(emd).getXmlElement().elementIterator().next();

--- a/src/test/resources/output/example2.xml
+++ b/src/test/resources/output/example2.xml
@@ -105,7 +105,7 @@
         <dc:language>fr</dc:language>
     </emd:language>
     <emd:relation>
-        <dc:relation eas:schemeId="STREAMING_SURROGATE_RELATION">/domain/dans/user/somebody/collection/test1/presentation/testA</dc:relation>
+        <dc:relation eas:scheme="STREAMING_SURROGATE_RELATION">/domain/dans/user/somebody/collection/test1/presentation/testA</dc:relation>
         <dc:relation>urn:nbn:nl:ui:13-fant-asy</dc:relation>
         <dc:relation>10.5072/fantasy-doi-rel</dc:relation>
         <dct:conformsTo>http://doi.org/10.1111/sode.12120</dct:conformsTo>


### PR DESCRIPTION
fixes EASY-1323

#### When applied it will
* Change the crosswalker so it stores the STREAMING-SURROGATE-RELATION in a eas:scheme instead of eas:schemeId for the EMD

#### Where should the reviewer @DANS-KNAW/easy start?

