### PR TITLE
EASY-1374: ddm:subject in DDM to EMD transformation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <name>Dans Dataset Metadata Library (DDM)</name>
     <inceptionYear>2014</inceptionYear>
     <properties>
-        <easy.schema.version>1.14.0</easy.schema.version>
+        <easy.schema.version>1.15.0</easy.schema.version>
         <easy.emd.version>3.7.1</easy.emd.version>
     </properties>
     <scm>

--- a/src/main/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdHandlerMap.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdHandlerMap.java
@@ -434,6 +434,7 @@ public class Ddm2EmdHandlerMap implements CrosswalkHandlerMap<EasyMetadata> {
         final BasicStringHandler abrSubjectHandler = new SubjectHandler(NameSpace.ABR);
         map.put("/dc:subject", subjectHandler);
         map.put("/dcterms:subject", subjectHandler);
+        map.put("/ddm:subject", subjectHandler);
         map.put("ABRcomplex/dc:subject", abrSubjectHandler);
         map.put("ABRcomplex/dcterms:subject", abrSubjectHandler);
         // <ref-panelId>dc.subject.abr</ref-panelId>

--- a/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
@@ -994,6 +994,36 @@ public class Ddm2EmdCrosswalkTest {
     }
 
     @Test
+    public void ddmSubject() throws Exception {
+        // @formatter:off
+        String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM" +
+                "  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'" +
+                "  xmlns:ddm='http://easy.dans.knaw.nl/schemas/md/ddm/'" +
+                "  xmlns:dc='http://purl.org/dc/elements/1.1/'" +
+                "  xmlns:abr='http://www.den.nl/standaard/166/Archeologisch-Basisregister/'>" +
+                " <ddm:dcmiMetadata>" +
+                "  <ddm:subject subjectScheme='Art and Architecture Thesaurus'" +
+                "               schemeURI='http://vocab.getty.edu/aat/'" +
+                "               valueURI='http://vocab.getty.edu/aat/300209303'" +
+                "               xml:lang='en'>fibulae</ddm:subject>" +
+                " </ddm:dcmiMetadata>" +
+                "</ddm:DDM>";
+        // @formatter:on
+
+        DefaultElement top = firstEmdElementFrom(ddm);
+
+        DefaultElement sub = (DefaultElement) top.elements().get(0);
+
+        assertThat(top.elements().size(), is(1));
+        assertThat(top.getQualifiedName(), is("emd:subject"));
+        assertThat(sub.getQualifiedName(), is("dc:subject"));
+        assertThat(sub.getText(), is("fibulae"));
+        assertThat(sub.attributeCount(), is(1));
+        assertThat(sub.attribute("lang").getQualifiedName(), is("xml:lang"));
+        assertThat(sub.attribute("lang").getValue(), is("en"));
+    }
+
+    @Test
     public void streamingSurrogateRelation() throws Exception {
         // @formatter:off
         String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM" +

--- a/src/test/resources/output/example1.xml
+++ b/src/test/resources/output/example1.xml
@@ -18,6 +18,7 @@
     <emd:subject>
         <dc:subject>school leavers</dc:subject>
         <dc:subject>labour market</dc:subject>
+        <dc:subject xml:lang="en">fibulae</dc:subject>
     </emd:subject>
     <emd:description>
         <dc:description xml:lang="la">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</dc:description>


### PR DESCRIPTION
fixes EASY-1374

#### When applied it will
* add the `ddm:subject` to the crosswalker

@DANS-KNAW/easy for review
@lindareijnhoudt please review, merge, release on artifactory and let me know the new version number on artifactory (probably 3.7.0?); thanks!