### PR TITLE
EASY-1474: Handle ddm:temporal like ddm:subject

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <name>Dans Dataset Metadata Library (DDM)</name>
     <inceptionYear>2014</inceptionYear>
     <properties>
-        <easy.schema.version>1.15.1</easy.schema.version>
+        <easy.schema.version>1.16.1</easy.schema.version>
         <easy.emd.version>3.7.1</easy.emd.version>
     </properties>
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <name>Dans Dataset Metadata Library (DDM)</name>
     <inceptionYear>2014</inceptionYear>
     <properties>
-        <easy.schema.version>1.15.0</easy.schema.version>
+        <easy.schema.version>1.15.1</easy.schema.version>
         <easy.emd.version>3.7.1</easy.emd.version>
     </properties>
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <groupId>nl.knaw.dans.easy</groupId>
     <artifactId>ddm</artifactId>
-    <version>3.6.2</version>
+    <version>3.6.3-SNAPSHOT</version>
     <name>Dans Dataset Metadata Library (DDM)</name>
     <inceptionYear>2014</inceptionYear>
     <properties>
@@ -34,7 +34,7 @@
     </properties>
     <scm>
         <developerConnection>scm:git:https://github.com/DANS-KNAW/${project.artifactId}</developerConnection>
-        <tag>v3.6.2</tag>
+        <tag>HEAD</tag>
     </scm>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-java-prototype</artifactId>
-        <version>1.58</version>
+        <version>1.61</version>
     </parent>
     <groupId>nl.knaw.dans.easy</groupId>
     <artifactId>ddm</artifactId>

--- a/src/main/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdHandlerMap.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdHandlerMap.java
@@ -424,7 +424,9 @@ public class Ddm2EmdHandlerMap implements CrosswalkHandlerMap<EasyMetadata> {
         // <ref-panelId>eas.spatial.box</ref-panelId>
         // getEmdCoverage().get...
 
-        map.put("/dcterms:temporal", new TermsTemporalHandler());
+        final TermsTemporalHandler temporalHandler = new TermsTemporalHandler();
+        map.put("/dcterms:temporal", temporalHandler);
+        map.put("/ddm:temporal", temporalHandler);
         map.put("ABRperiode/dcterms:temporal", new TermsTemporalHandler(NameSpace.ABR));
         // <ref-panelId>dcterms.temporal</ref-panelId>
         // <ref-panelId>dcterms.temporal.abr</ref-panelId>

--- a/src/main/java/nl/knaw/dans/pf/language/ddm/handlermaps/NameSpace.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/handlermaps/NameSpace.java
@@ -23,7 +23,7 @@ public enum NameSpace {
     GML("gml", "http://www.opengis.net/gml", "http://schemas.opengis.net/gml/3.2.1/gml.xsd"), //
     DCX_DAI("dcx-dai", "http://easy.dans.knaw.nl/schemas/dcx/dai/", "http://easy.dans.knaw.nl/schemas/dcx/2017/09/dcx-dai.xsd"), //
     DCX_GML("dcx-gml", "http://easy.dans.knaw.nl/schemas/dcx/gml/", "http://easy.dans.knaw.nl/schemas/dcx/2016/dcx-gml.xsd"), //
-    DDM("ddm", "http://easy.dans.knaw.nl/schemas/md/ddm/", "http://easy.dans.knaw.nl/schemas/md/2017/09/ddm.xsd"), //
+    DDM("ddm", "http://easy.dans.knaw.nl/schemas/md/ddm/", "http://easy.dans.knaw.nl/schemas/md/2018/02/ddm.xsd"), //
     XSI("xsi", "http://www.w3.org/2001/XMLSchema-instance", "https://www.w3.org/2001/XMLSchema-instance"), //
     NARCIS_TYPE("narcis", "http://easy.dans.knaw.nl/schemas/vocab/narcis-type/", "http://easy.dans.knaw.nl/schemas/vocab/2015/narcis-type.xsd"), //
     IDENTIFIER_TYPE("id-type", "http://easy.dans.knaw.nl/schemas/vocab/identifier-type/", "http://easy.dans.knaw.nl/schemas/vocab/2017/09/identifier-type.xsd"), //


### PR DESCRIPTION
fixes EASY-1474

#### When applied it will
* Handle ddm:temporal like ddm:subject
So it will 
* Accept the tag, with the attributes
* Ignore the attributes when transforming to EMD

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ---
easy-schema                      | [PR#55](https://github.com/DANS-KNAW/easy-schema/pull/55)     | 
