### PR TITLE
EASY-1479: DDM to EMD should parse ISO 3166, and other bugs

### DIFF
--- a/src/main/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdHandlerMap.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdHandlerMap.java
@@ -56,6 +56,7 @@ import nl.knaw.dans.pf.language.ddm.handlers.SkippedFieldHandler;
 import nl.knaw.dans.pf.language.ddm.handlers.SubjectHandler;
 import nl.knaw.dans.pf.language.ddm.handlers.TermsRightsHolderHandler;
 import nl.knaw.dans.pf.language.ddm.handlers.TermsSpatialHandler;
+import nl.knaw.dans.pf.language.ddm.handlers.TermsSpatialIso3166Handler;
 import nl.knaw.dans.pf.language.ddm.handlers.TermsTemporalHandler;
 import nl.knaw.dans.pf.language.ddm.handlers.TitleHandler;
 import nl.knaw.dans.pf.language.ddm.handlers.ArchisIdentifierHandler;
@@ -417,6 +418,7 @@ public class Ddm2EmdHandlerMap implements CrosswalkHandlerMap<EasyMetadata> {
 
         final EasSpatialHandler easSpatialHandler = new EasSpatialHandler();
         map.put("/dcterms:spatial", new TermsSpatialHandler());
+        map.put("ISO3166/dcterms:spatial", new TermsSpatialIso3166Handler());
         map.put("/dcx-gml:spatial", easSpatialHandler);
         map.put("SimpleGMLType/dcterms:spatial", easSpatialHandler);
         // <ref-panelId>dcterms.spatial</ref-panelId>

--- a/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/AccessRightsHandler.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/AccessRightsHandler.java
@@ -27,6 +27,7 @@ public class AccessRightsHandler extends BasicStringHandler {
     public final void finishElement(final String uri, final String localName) throws SAXException {
         final List<BasicString> accessRightsList = getTarget().getEmdRights().getTermsAccessRights();
         final BasicString basicString = createBasicString(uri, localName);
+        basicString.setSchemeId("common.dcterms.accessrights");
         // skip access rights beyond the ddm:profile
         if (accessRightsList.size() <= 0 && basicString != null)
             accessRightsList.add(basicString);

--- a/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/EasSpatialHandler.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/EasSpatialHandler.java
@@ -91,8 +91,15 @@ public class EasSpatialHandler extends CrosswalkHandler<EasyMetadata> {
             state = state.getNextState();
         else if ("exterior".equals(localName) && state == P_DESCR)
             state = state.getNextState();
+        else if ("exterior".equals(localName) && state == POLYGON)
+            // no description in the polygon
+            state = P_DESCR.getNextState();
         else if ("posList".equals(localName) && (state == E_DESCR || state == I_DESCR))
             state = state.getNextState();
+        else if ("posList".equals(localName) && state == EXTERIOR)
+            state = E_DESCR.getNextState();
+        else if ("posList".equals(localName) && state == INTERIOR)
+            state = I_DESCR.getNextState();
         else if ("interior".equals(localName))
             state = INTERIOR;
     }
@@ -141,6 +148,11 @@ public class EasSpatialHandler extends CrosswalkHandler<EasyMetadata> {
             Spatial.Polygon polygon = createPolygon();
             getTarget().getEmdCoverage().getEasSpatial().add(new Spatial(polygonDescription, polygon));
             state = state.getNextState();
+        } else if ("Polygon".equals(localName) && state == INTERIOR) {
+            // no interior(s) found
+            Spatial.Polygon polygon = createPolygon();
+            getTarget().getEmdCoverage().getEasSpatial().add(new Spatial(polygonDescription, polygon));
+            state = END_POLYGON.getNextState();
         } else if ("Point".equals(localName) && pos != null)
             getTarget().getEmdCoverage().getEasSpatial().add(new Spatial(description, pos));
         else if ("Envelope".equals(localName) && lower != null && upper != null)

--- a/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/TermsSpatialIso3166Handler.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/TermsSpatialIso3166Handler.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2014 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.pf.language.ddm.handlers;
+
+import nl.knaw.dans.pf.language.ddm.handlertypes.BasicStringHandler;
+import nl.knaw.dans.pf.language.emd.types.BasicString;
+import org.xml.sax.SAXException;
+
+import static org.apache.commons.lang.StringUtils.isBlank;
+
+public class TermsSpatialIso3166Handler extends BasicStringHandler {
+
+    @Override
+    protected void finishElement(final String uri, final String localName) throws SAXException {
+        BasicString basicString = createBasicString(uri, localName);
+
+        if (basicString != null) {
+            String newValue = convertIsoValue(basicString.getValue());
+            basicString.setValue(newValue);
+
+            // the uri check prevents creating an element for each level of
+            // for example: <dcterms:spatial><Point><pos>
+            if (!isBlank(uri))
+                getTarget().getEmdCoverage().getTermsSpatial().add(basicString);
+        }
+    }
+
+    private String convertIsoValue(String value) {
+        String s = value.toUpperCase();
+        if ("NLD".equals(s)) {
+            return "Netherlands";
+        } else {
+            return value;
+        }
+    }
+}

--- a/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
@@ -888,6 +888,30 @@ public class Ddm2EmdCrosswalkTest {
     }
 
     @Test
+    public void spatialISO3166() throws Exception {
+        // @formatter:off
+        String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM" +
+                "  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'" +
+                "  xmlns:ddm='http://easy.dans.knaw.nl/schemas/md/ddm/'" +
+                "  xmlns:dcterms='http://purl.org/dc/terms/'" +
+                ">" +
+                " <ddm:dcmiMetadata>" +
+                "  <dcterms:spatial xsi:type=\"dcterms:ISO3166\">NLD</dcterms:spatial>"+
+                " </ddm:dcmiMetadata>" +
+                "</ddm:DDM>";
+        // @formatter:on
+
+        DefaultElement top = firstEmdElementFrom(ddm);
+
+        DefaultElement sub = (DefaultElement) top.elements().get(0);
+
+        assertThat(top.elements().size(), is(1));
+        assertThat(top.getQualifiedName(), is("emd:coverage"));
+        assertThat(sub.getQualifiedName(), is("dct:spatial"));
+        assertThat(sub.getText(), is("Netherlands"));
+    }
+
+    @Test
     public void temporalPlainText() throws Exception {
         // @formatter:off
         String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM" +

--- a/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
@@ -32,6 +32,32 @@ import static org.junit.Assert.assertTrue;
 public class Ddm2EmdCrosswalkTest {
 
     @Test
+    public void ddmAccessRight() throws Exception {
+        // @formatter:off
+        String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM"
+            + "  xmlns:dc='http://purl.org/dc/elements/1.1/'"
+            + "  xmlns:ddm='http://easy.dans.knaw.nl/schemas/md/ddm/'"
+            + "  xmlns:dcterms='http://purl.org/dc/terms/'"
+            + "  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>"
+            + "  <ddm:profile>"
+            + "    <ddm:accessRights>OPEN_ACCESS</ddm:accessRights>"
+            + "  </ddm:profile>"
+            + "</ddm:DDM>";
+        // @formatter:on
+
+        DefaultElement top = firstEmdElementFrom(ddm);
+        assertThat(top.elements().size(), is(1));
+        assertThat(top.getQualifiedName(), is("emd:rights"));
+
+        DefaultElement sub = (DefaultElement) top.elements().get(0);
+        assertThat(sub.getQualifiedName(), is("dct:accessRights"));
+        assertThat(sub.getText(), is("OPEN_ACCESS"));
+        assertThat(sub.attributeCount(), is(1));
+        assertThat(sub.attribute("schemeId").getQualifiedName(), is("eas:schemeId"));
+        assertThat(sub.attribute("schemeId").getValue(), is("common.dcterms.accessrights"));
+    }
+
+    @Test
     public void identifierWithIdTypeEDNA() throws Exception {
         // @formatter:off
         String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM"

--- a/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
@@ -592,6 +592,9 @@ public class Ddm2EmdCrosswalkTest {
         assertThat(interior1.elements().size(), is(5));
         assertThat(interior1.getQualifiedName(), is("eas:polygon-interior"));
 
+        assertThat(interior2.elements().size(), is(5));
+        assertThat(interior2.getQualifiedName(), is("eas:polygon-interior"));
+
         assertTrue(exPlace.elements().isEmpty());
         assertThat(exPlace.getQualifiedName(), is("eas:place"));
         assertThat(exPlace.getText(), is("main triangle"));
@@ -792,6 +795,9 @@ public class Ddm2EmdCrosswalkTest {
         assertThat(interior1.elements().size(), is(5));
         assertThat(interior1.getQualifiedName(), is("eas:polygon-interior"));
 
+        assertThat(interior2.elements().size(), is(5));
+        assertThat(interior2.getQualifiedName(), is("eas:polygon-interior"));
+
         assertTrue(exPlace.elements().isEmpty());
         assertThat(exPlace.getQualifiedName(), is("eas:place"));
         assertThat(exPlace.getText(), is("main triangle"));
@@ -911,6 +917,461 @@ public class Ddm2EmdCrosswalkTest {
         assertTrue(((DefaultElement) in24.elements().get(1)).elements().isEmpty());
         assertThat(((DefaultElement) in24.elements().get(1)).getQualifiedName(), is("eas:y"));
         assertThat(((DefaultElement) in24.elements().get(1)).getText(), is("455210"));
+    }
+
+    @Test
+    public void spatialPolygonWithoutDescriptionsOrInternals() throws Exception {
+        // @formatter:off
+        String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM" +
+            "  xmlns:ddm='http://easy.dans.knaw.nl/schemas/md/ddm/'" +
+            "  xmlns:gml='http://www.opengis.net/gml'" +
+            "  xmlns:dcx-gml='http://easy.dans.knaw.nl/schemas/dcx/gml/'>" +
+            " <ddm:dcmiMetadata>" +
+            "   <dcx-gml:spatial>" +
+            "     <Polygon xmlns='http://www.opengis.net/gml' srsName='http://www.opengis.net/def/crs/EPSG/0/4326'>" +
+            "       <exterior>" +
+            "         <LinearRing>" +
+            "           <posList>52.08110 4.34521 52.08071 4.34422 52.07913 4.34332 52.08110 4.34521</posList>" +
+            "         </LinearRing>" +
+            "       </exterior>" +
+            "     </Polygon>" +
+            "   </dcx-gml:spatial>" +
+            " </ddm:dcmiMetadata>" +
+            "</ddm:DDM>";
+        // @formatter:on
+
+        DefaultElement coverage = firstEmdElementFrom(ddm);
+        DefaultElement spatial = (DefaultElement) coverage.elements().get(0);
+        DefaultElement place = (DefaultElement) spatial.elements().get(0);
+        DefaultElement polygon = (DefaultElement) spatial.elements().get(1);
+        DefaultElement exterior = (DefaultElement) polygon.elements().get(0);
+        DefaultElement ex1 = (DefaultElement) exterior.elements().get(0);
+        DefaultElement ex2 = (DefaultElement) exterior.elements().get(1);
+        DefaultElement ex3 = (DefaultElement) exterior.elements().get(2);
+        DefaultElement ex4 = (DefaultElement) exterior.elements().get(3);
+
+        assertThat(coverage.elements().size(), is(1));
+        assertThat(coverage.getQualifiedName(), is("emd:coverage"));
+
+        assertThat(spatial.elements().size(), is(2));
+        assertThat(spatial.getQualifiedName(), is("eas:spatial"));
+
+        assertTrue(place.elements().isEmpty());
+        assertThat(place.getQualifiedName(), is("eas:place"));
+        // empty here, because this originates from a BasicString (and can therefore contain attributes, which requires a render),
+        // while the eas:place in exterior/interior is a String
+        assertThat(place.getText(), is(""));
+
+        assertThat(polygon.elements().size(), is(1));
+        assertThat(polygon.getQualifiedName(), is("eas:polygon"));
+        assertThat(polygon.attribute("scheme").getQualifiedName(), is("eas:scheme"));
+        assertThat(polygon.attribute("scheme").getValue(), is("degrees"));
+
+        assertThat(exterior.elements().size(), is(4));
+        assertThat(exterior.getQualifiedName(), is("eas:polygon-exterior"));
+
+        assertThat(ex1.elements().size(), is(2));
+        assertThat(ex1.getQualifiedName(), is("eas:polygon-point"));
+        assertTrue(((DefaultElement) ex1.elements().get(0)).elements().isEmpty());
+        assertThat(((DefaultElement) ex1.elements().get(0)).getQualifiedName(), is("eas:x"));
+        assertThat(((DefaultElement) ex1.elements().get(0)).getText(), is("52.08110"));
+        assertTrue(((DefaultElement) ex1.elements().get(1)).elements().isEmpty());
+        assertThat(((DefaultElement) ex1.elements().get(1)).getQualifiedName(), is("eas:y"));
+        assertThat(((DefaultElement) ex1.elements().get(1)).getText(), is("4.34521"));
+
+        assertThat(ex2.elements().size(), is(2));
+        assertThat(ex2.getQualifiedName(), is("eas:polygon-point"));
+        assertTrue(((DefaultElement) ex2.elements().get(0)).elements().isEmpty());
+        assertThat(((DefaultElement) ex2.elements().get(0)).getQualifiedName(), is("eas:x"));
+        assertThat(((DefaultElement) ex2.elements().get(0)).getText(), is("52.08071"));
+        assertTrue(((DefaultElement) ex2.elements().get(1)).elements().isEmpty());
+        assertThat(((DefaultElement) ex2.elements().get(1)).getQualifiedName(), is("eas:y"));
+        assertThat(((DefaultElement) ex2.elements().get(1)).getText(), is("4.34422"));
+
+        assertThat(ex3.elements().size(), is(2));
+        assertThat(ex3.getQualifiedName(), is("eas:polygon-point"));
+        assertTrue(((DefaultElement) ex3.elements().get(0)).elements().isEmpty());
+        assertThat(((DefaultElement) ex3.elements().get(0)).getQualifiedName(), is("eas:x"));
+        assertThat(((DefaultElement) ex3.elements().get(0)).getText(), is("52.07913"));
+        assertTrue(((DefaultElement) ex3.elements().get(1)).elements().isEmpty());
+        assertThat(((DefaultElement) ex3.elements().get(1)).getQualifiedName(), is("eas:y"));
+        assertThat(((DefaultElement) ex3.elements().get(1)).getText(), is("4.34332"));
+
+        assertThat(ex4.elements().size(), is(2));
+        assertThat(ex4.getQualifiedName(), is("eas:polygon-point"));
+        assertTrue(((DefaultElement) ex4.elements().get(0)).elements().isEmpty());
+        assertThat(((DefaultElement) ex4.elements().get(0)).getQualifiedName(), is("eas:x"));
+        assertThat(((DefaultElement) ex4.elements().get(0)).getText(), is("52.08110"));
+        assertTrue(((DefaultElement) ex4.elements().get(1)).elements().isEmpty());
+        assertThat(((DefaultElement) ex4.elements().get(1)).getQualifiedName(), is("eas:y"));
+        assertThat(((DefaultElement) ex4.elements().get(1)).getText(), is("4.34521"));
+    }
+
+    @Test
+    public void spatialPolygonWithOnlyDescriptionInExternal() throws Exception {
+        // @formatter:off
+        String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM" +
+            "  xmlns:ddm='http://easy.dans.knaw.nl/schemas/md/ddm/'" +
+            "  xmlns:gml='http://www.opengis.net/gml'" +
+            "  xmlns:dcx-gml='http://easy.dans.knaw.nl/schemas/dcx/gml/'>" +
+            " <ddm:dcmiMetadata>" +
+            "   <dcx-gml:spatial>" +
+            "     <Polygon xmlns='http://www.opengis.net/gml' srsName='http://www.opengis.net/def/crs/EPSG/0/4326'>" +
+            "       <exterior>" +
+            "         <LinearRing>" +
+            "           <description>main triangle</description>" +
+            "           <posList>52.08110 4.34521 52.08071 4.34422 52.07913 4.34332 52.08110 4.34521</posList>" +
+            "         </LinearRing>" +
+            "       </exterior>" +
+            "     </Polygon>" +
+            "   </dcx-gml:spatial>" +
+            " </ddm:dcmiMetadata>" +
+            "</ddm:DDM>";
+        // @formatter:on
+
+        DefaultElement coverage = firstEmdElementFrom(ddm);
+        DefaultElement spatial = (DefaultElement) coverage.elements().get(0);
+        DefaultElement place = (DefaultElement) spatial.elements().get(0);
+        DefaultElement polygon = (DefaultElement) spatial.elements().get(1);
+        DefaultElement exterior = (DefaultElement) polygon.elements().get(0);
+        DefaultElement exPlace = (DefaultElement) exterior.elements().get(0);
+        DefaultElement ex1 = (DefaultElement) exterior.elements().get(1);
+        DefaultElement ex2 = (DefaultElement) exterior.elements().get(2);
+        DefaultElement ex3 = (DefaultElement) exterior.elements().get(3);
+        DefaultElement ex4 = (DefaultElement) exterior.elements().get(4);
+
+        assertThat(coverage.elements().size(), is(1));
+        assertThat(coverage.getQualifiedName(), is("emd:coverage"));
+
+        assertThat(spatial.elements().size(), is(2));
+        assertThat(spatial.getQualifiedName(), is("eas:spatial"));
+
+        assertTrue(place.elements().isEmpty());
+        assertThat(place.getQualifiedName(), is("eas:place"));
+        // empty here, because this originates from a BasicString (and can therefore contain attributes, which requires a render),
+        // while the eas:place in exterior/interior is a String
+        assertThat(place.getText(), is(""));
+
+        assertThat(polygon.elements().size(), is(1));
+        assertThat(polygon.getQualifiedName(), is("eas:polygon"));
+        assertThat(polygon.attribute("scheme").getQualifiedName(), is("eas:scheme"));
+        assertThat(polygon.attribute("scheme").getValue(), is("degrees"));
+
+        assertThat(exterior.elements().size(), is(5));
+        assertThat(exterior.getQualifiedName(), is("eas:polygon-exterior"));
+
+        assertTrue(exPlace.elements().isEmpty());
+        assertThat(exPlace.getQualifiedName(), is("eas:place"));
+        assertThat(exPlace.getText(), is("main triangle"));
+
+        assertThat(ex1.elements().size(), is(2));
+        assertThat(ex1.getQualifiedName(), is("eas:polygon-point"));
+        assertTrue(((DefaultElement) ex1.elements().get(0)).elements().isEmpty());
+        assertThat(((DefaultElement) ex1.elements().get(0)).getQualifiedName(), is("eas:x"));
+        assertThat(((DefaultElement) ex1.elements().get(0)).getText(), is("52.08110"));
+        assertTrue(((DefaultElement) ex1.elements().get(1)).elements().isEmpty());
+        assertThat(((DefaultElement) ex1.elements().get(1)).getQualifiedName(), is("eas:y"));
+        assertThat(((DefaultElement) ex1.elements().get(1)).getText(), is("4.34521"));
+
+        assertThat(ex2.elements().size(), is(2));
+        assertThat(ex2.getQualifiedName(), is("eas:polygon-point"));
+        assertTrue(((DefaultElement) ex2.elements().get(0)).elements().isEmpty());
+        assertThat(((DefaultElement) ex2.elements().get(0)).getQualifiedName(), is("eas:x"));
+        assertThat(((DefaultElement) ex2.elements().get(0)).getText(), is("52.08071"));
+        assertTrue(((DefaultElement) ex2.elements().get(1)).elements().isEmpty());
+        assertThat(((DefaultElement) ex2.elements().get(1)).getQualifiedName(), is("eas:y"));
+        assertThat(((DefaultElement) ex2.elements().get(1)).getText(), is("4.34422"));
+
+        assertThat(ex3.elements().size(), is(2));
+        assertThat(ex3.getQualifiedName(), is("eas:polygon-point"));
+        assertTrue(((DefaultElement) ex3.elements().get(0)).elements().isEmpty());
+        assertThat(((DefaultElement) ex3.elements().get(0)).getQualifiedName(), is("eas:x"));
+        assertThat(((DefaultElement) ex3.elements().get(0)).getText(), is("52.07913"));
+        assertTrue(((DefaultElement) ex3.elements().get(1)).elements().isEmpty());
+        assertThat(((DefaultElement) ex3.elements().get(1)).getQualifiedName(), is("eas:y"));
+        assertThat(((DefaultElement) ex3.elements().get(1)).getText(), is("4.34332"));
+
+        assertThat(ex4.elements().size(), is(2));
+        assertThat(ex4.getQualifiedName(), is("eas:polygon-point"));
+        assertTrue(((DefaultElement) ex4.elements().get(0)).elements().isEmpty());
+        assertThat(((DefaultElement) ex4.elements().get(0)).getQualifiedName(), is("eas:x"));
+        assertThat(((DefaultElement) ex4.elements().get(0)).getText(), is("52.08110"));
+        assertTrue(((DefaultElement) ex4.elements().get(1)).elements().isEmpty());
+        assertThat(((DefaultElement) ex4.elements().get(1)).getQualifiedName(), is("eas:y"));
+        assertThat(((DefaultElement) ex4.elements().get(1)).getText(), is("4.34521"));
+    }
+
+    @Test
+    public void spatialPolygonWithoutInternals() throws Exception {
+        // @formatter:off
+        String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM" +
+            "  xmlns:ddm='http://easy.dans.knaw.nl/schemas/md/ddm/'" +
+            "  xmlns:gml='http://www.opengis.net/gml'" +
+            "  xmlns:dcx-gml='http://easy.dans.knaw.nl/schemas/dcx/gml/'>" +
+            " <ddm:dcmiMetadata>" +
+            "   <dcx-gml:spatial>" +
+            "     <Polygon xmlns='http://www.opengis.net/gml' srsName='http://www.opengis.net/def/crs/EPSG/0/4326'>" +
+            "       <description>A triangle between DANS, NWO and the railway station</description>" +
+            "       <exterior>" +
+            "         <LinearRing>" +
+            "           <posList>52.08110 4.34521 52.08071 4.34422 52.07913 4.34332 52.08110 4.34521</posList>" +
+            "         </LinearRing>" +
+            "       </exterior>" +
+            "     </Polygon>" +
+            "   </dcx-gml:spatial>" +
+            " </ddm:dcmiMetadata>" +
+            "</ddm:DDM>";
+        // @formatter:on
+
+        DefaultElement coverage = firstEmdElementFrom(ddm);
+        DefaultElement spatial = (DefaultElement) coverage.elements().get(0);
+        DefaultElement place = (DefaultElement) spatial.elements().get(0);
+        DefaultElement polygon = (DefaultElement) spatial.elements().get(1);
+        DefaultElement exterior = (DefaultElement) polygon.elements().get(0);
+        DefaultElement ex1 = (DefaultElement) exterior.elements().get(0);
+        DefaultElement ex2 = (DefaultElement) exterior.elements().get(1);
+        DefaultElement ex3 = (DefaultElement) exterior.elements().get(2);
+        DefaultElement ex4 = (DefaultElement) exterior.elements().get(3);
+
+        assertThat(coverage.elements().size(), is(1));
+        assertThat(coverage.getQualifiedName(), is("emd:coverage"));
+
+        assertThat(spatial.elements().size(), is(2));
+        assertThat(spatial.getQualifiedName(), is("eas:spatial"));
+
+        assertTrue(place.elements().isEmpty());
+        assertThat(place.getQualifiedName(), is("eas:place"));
+        assertThat(place.getText(), is("A triangle between DANS, NWO and the railway station"));
+
+        assertThat(polygon.elements().size(), is(1));
+        assertThat(polygon.getQualifiedName(), is("eas:polygon"));
+        assertThat(polygon.attribute("scheme").getQualifiedName(), is("eas:scheme"));
+        assertThat(polygon.attribute("scheme").getValue(), is("degrees"));
+
+        assertThat(exterior.elements().size(), is(4));
+        assertThat(exterior.getQualifiedName(), is("eas:polygon-exterior"));
+
+        assertThat(ex1.elements().size(), is(2));
+        assertThat(ex1.getQualifiedName(), is("eas:polygon-point"));
+        assertTrue(((DefaultElement) ex1.elements().get(0)).elements().isEmpty());
+        assertThat(((DefaultElement) ex1.elements().get(0)).getQualifiedName(), is("eas:x"));
+        assertThat(((DefaultElement) ex1.elements().get(0)).getText(), is("52.08110"));
+        assertTrue(((DefaultElement) ex1.elements().get(1)).elements().isEmpty());
+        assertThat(((DefaultElement) ex1.elements().get(1)).getQualifiedName(), is("eas:y"));
+        assertThat(((DefaultElement) ex1.elements().get(1)).getText(), is("4.34521"));
+
+        assertThat(ex2.elements().size(), is(2));
+        assertThat(ex2.getQualifiedName(), is("eas:polygon-point"));
+        assertTrue(((DefaultElement) ex2.elements().get(0)).elements().isEmpty());
+        assertThat(((DefaultElement) ex2.elements().get(0)).getQualifiedName(), is("eas:x"));
+        assertThat(((DefaultElement) ex2.elements().get(0)).getText(), is("52.08071"));
+        assertTrue(((DefaultElement) ex2.elements().get(1)).elements().isEmpty());
+        assertThat(((DefaultElement) ex2.elements().get(1)).getQualifiedName(), is("eas:y"));
+        assertThat(((DefaultElement) ex2.elements().get(1)).getText(), is("4.34422"));
+
+        assertThat(ex3.elements().size(), is(2));
+        assertThat(ex3.getQualifiedName(), is("eas:polygon-point"));
+        assertTrue(((DefaultElement) ex3.elements().get(0)).elements().isEmpty());
+        assertThat(((DefaultElement) ex3.elements().get(0)).getQualifiedName(), is("eas:x"));
+        assertThat(((DefaultElement) ex3.elements().get(0)).getText(), is("52.07913"));
+        assertTrue(((DefaultElement) ex3.elements().get(1)).elements().isEmpty());
+        assertThat(((DefaultElement) ex3.elements().get(1)).getQualifiedName(), is("eas:y"));
+        assertThat(((DefaultElement) ex3.elements().get(1)).getText(), is("4.34332"));
+
+        assertThat(ex4.elements().size(), is(2));
+        assertThat(ex4.getQualifiedName(), is("eas:polygon-point"));
+        assertTrue(((DefaultElement) ex4.elements().get(0)).elements().isEmpty());
+        assertThat(((DefaultElement) ex4.elements().get(0)).getQualifiedName(), is("eas:x"));
+        assertThat(((DefaultElement) ex4.elements().get(0)).getText(), is("52.08110"));
+        assertTrue(((DefaultElement) ex4.elements().get(1)).elements().isEmpty());
+        assertThat(((DefaultElement) ex4.elements().get(1)).getQualifiedName(), is("eas:y"));
+        assertThat(((DefaultElement) ex4.elements().get(1)).getText(), is("4.34521"));
+    }
+
+    @Test
+    public void spatialPolygonWithoutDescriptions() throws Exception {
+        // @formatter:off
+        String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM" +
+            "  xmlns:ddm='http://easy.dans.knaw.nl/schemas/md/ddm/'" +
+            "  xmlns:gml='http://www.opengis.net/gml'" +
+            "  xmlns:dcx-gml='http://easy.dans.knaw.nl/schemas/dcx/gml/'>" +
+            " <ddm:dcmiMetadata>" +
+            "   <dcx-gml:spatial>" +
+            "     <Polygon xmlns='http://www.opengis.net/gml' srsName='http://www.opengis.net/def/crs/EPSG/0/4326'>" +
+            "       <exterior>" +
+            "         <LinearRing>" +
+            "           <posList>52.08110 4.34521 52.08071 4.34422 52.07913 4.34332 52.08110 4.34521</posList>" +
+            "         </LinearRing>" +
+            "       </exterior>" +
+            "       <interior>" +
+            "         <LinearRing>" +
+            "           <posList>52.080542 4.344215 52.080450 4.344323 52.080357 4.344110 52.080542 4.344215</posList>" +
+            "         </LinearRing>" +
+            "       </interior>" +
+            "       <interior>" +
+            "         <LinearRing>" +
+            "           <posList>52.080542 4.344215 52.080450 4.344323 52.080357 4.344110 52.080542 4.344215</posList>" +
+            "         </LinearRing>" +
+            "       </interior>" +
+            "     </Polygon>" +
+            "   </dcx-gml:spatial>" +
+            " </ddm:dcmiMetadata>" +
+            "</ddm:DDM>";
+        // @formatter:on
+
+        DefaultElement coverage = firstEmdElementFrom(ddm);
+        DefaultElement spatial = (DefaultElement) coverage.elements().get(0);
+        DefaultElement place = (DefaultElement) spatial.elements().get(0);
+        DefaultElement polygon = (DefaultElement) spatial.elements().get(1);
+        DefaultElement exterior = (DefaultElement) polygon.elements().get(0);
+        DefaultElement interior1 = (DefaultElement) polygon.elements().get(1);
+        DefaultElement interior2 = (DefaultElement) polygon.elements().get(2);
+        DefaultElement ex1 = (DefaultElement) exterior.elements().get(0);
+        DefaultElement ex2 = (DefaultElement) exterior.elements().get(1);
+        DefaultElement ex3 = (DefaultElement) exterior.elements().get(2);
+        DefaultElement ex4 = (DefaultElement) exterior.elements().get(3);
+        DefaultElement in11 = (DefaultElement) interior1.elements().get(0);
+        DefaultElement in12 = (DefaultElement) interior1.elements().get(1);
+        DefaultElement in13 = (DefaultElement) interior1.elements().get(2);
+        DefaultElement in14 = (DefaultElement) interior1.elements().get(3);
+        DefaultElement in21 = (DefaultElement) interior2.elements().get(0);
+        DefaultElement in22 = (DefaultElement) interior2.elements().get(1);
+        DefaultElement in23 = (DefaultElement) interior2.elements().get(2);
+        DefaultElement in24 = (DefaultElement) interior2.elements().get(3);
+
+        assertThat(coverage.elements().size(), is(1));
+        assertThat(coverage.getQualifiedName(), is("emd:coverage"));
+
+        assertThat(spatial.elements().size(), is(2));
+        assertThat(spatial.getQualifiedName(), is("eas:spatial"));
+
+        assertTrue(place.elements().isEmpty());
+        assertThat(place.getQualifiedName(), is("eas:place"));
+          // empty here, because this originates from a BasicString (and can therefore contain attributes, which requires a render),
+          // while the eas:place in exterior/interior is a String
+        assertThat(place.getText(), is(""));
+
+        assertThat(polygon.elements().size(), is(3));
+        assertThat(polygon.getQualifiedName(), is("eas:polygon"));
+        assertThat(polygon.attribute("scheme").getQualifiedName(), is("eas:scheme"));
+        assertThat(polygon.attribute("scheme").getValue(), is("degrees"));
+
+        assertThat(exterior.elements().size(), is(4));
+        assertThat(exterior.getQualifiedName(), is("eas:polygon-exterior"));
+
+        assertThat(interior1.elements().size(), is(4));
+        assertThat(interior1.getQualifiedName(), is("eas:polygon-interior"));
+
+        assertThat(interior2.elements().size(), is(4));
+        assertThat(interior2.getQualifiedName(), is("eas:polygon-interior"));
+
+        assertThat(ex1.elements().size(), is(2));
+        assertThat(ex1.getQualifiedName(), is("eas:polygon-point"));
+        assertTrue(((DefaultElement) ex1.elements().get(0)).elements().isEmpty());
+        assertThat(((DefaultElement) ex1.elements().get(0)).getQualifiedName(), is("eas:x"));
+        assertThat(((DefaultElement) ex1.elements().get(0)).getText(), is("52.08110"));
+        assertTrue(((DefaultElement) ex1.elements().get(1)).elements().isEmpty());
+        assertThat(((DefaultElement) ex1.elements().get(1)).getQualifiedName(), is("eas:y"));
+        assertThat(((DefaultElement) ex1.elements().get(1)).getText(), is("4.34521"));
+
+        assertThat(ex2.elements().size(), is(2));
+        assertThat(ex2.getQualifiedName(), is("eas:polygon-point"));
+        assertTrue(((DefaultElement) ex2.elements().get(0)).elements().isEmpty());
+        assertThat(((DefaultElement) ex2.elements().get(0)).getQualifiedName(), is("eas:x"));
+        assertThat(((DefaultElement) ex2.elements().get(0)).getText(), is("52.08071"));
+        assertTrue(((DefaultElement) ex2.elements().get(1)).elements().isEmpty());
+        assertThat(((DefaultElement) ex2.elements().get(1)).getQualifiedName(), is("eas:y"));
+        assertThat(((DefaultElement) ex2.elements().get(1)).getText(), is("4.34422"));
+
+        assertThat(ex3.elements().size(), is(2));
+        assertThat(ex3.getQualifiedName(), is("eas:polygon-point"));
+        assertTrue(((DefaultElement) ex3.elements().get(0)).elements().isEmpty());
+        assertThat(((DefaultElement) ex3.elements().get(0)).getQualifiedName(), is("eas:x"));
+        assertThat(((DefaultElement) ex3.elements().get(0)).getText(), is("52.07913"));
+        assertTrue(((DefaultElement) ex3.elements().get(1)).elements().isEmpty());
+        assertThat(((DefaultElement) ex3.elements().get(1)).getQualifiedName(), is("eas:y"));
+        assertThat(((DefaultElement) ex3.elements().get(1)).getText(), is("4.34332"));
+
+        assertThat(ex4.elements().size(), is(2));
+        assertThat(ex4.getQualifiedName(), is("eas:polygon-point"));
+        assertTrue(((DefaultElement) ex4.elements().get(0)).elements().isEmpty());
+        assertThat(((DefaultElement) ex4.elements().get(0)).getQualifiedName(), is("eas:x"));
+        assertThat(((DefaultElement) ex4.elements().get(0)).getText(), is("52.08110"));
+        assertTrue(((DefaultElement) ex4.elements().get(1)).elements().isEmpty());
+        assertThat(((DefaultElement) ex4.elements().get(1)).getQualifiedName(), is("eas:y"));
+        assertThat(((DefaultElement) ex4.elements().get(1)).getText(), is("4.34521"));
+
+        assertThat(in11.elements().size(), is(2));
+        assertThat(in11.getQualifiedName(), is("eas:polygon-point"));
+        assertTrue(((DefaultElement) in11.elements().get(0)).elements().isEmpty());
+        assertThat(((DefaultElement) in11.elements().get(0)).getQualifiedName(), is("eas:x"));
+        assertThat(((DefaultElement) in11.elements().get(0)).getText(), is("52.080542"));
+        assertTrue(((DefaultElement) in11.elements().get(1)).elements().isEmpty());
+        assertThat(((DefaultElement) in11.elements().get(1)).getQualifiedName(), is("eas:y"));
+        assertThat(((DefaultElement) in11.elements().get(1)).getText(), is("4.344215"));
+
+        assertThat(in12.elements().size(), is(2));
+        assertThat(in12.getQualifiedName(), is("eas:polygon-point"));
+        assertTrue(((DefaultElement) in12.elements().get(0)).elements().isEmpty());
+        assertThat(((DefaultElement) in12.elements().get(0)).getQualifiedName(), is("eas:x"));
+        assertThat(((DefaultElement) in12.elements().get(0)).getText(), is("52.080450"));
+        assertTrue(((DefaultElement) in12.elements().get(1)).elements().isEmpty());
+        assertThat(((DefaultElement) in12.elements().get(1)).getQualifiedName(), is("eas:y"));
+        assertThat(((DefaultElement) in12.elements().get(1)).getText(), is("4.344323"));
+
+        assertThat(in13.elements().size(), is(2));
+        assertThat(in13.getQualifiedName(), is("eas:polygon-point"));
+        assertTrue(((DefaultElement) in13.elements().get(0)).elements().isEmpty());
+        assertThat(((DefaultElement) in13.elements().get(0)).getQualifiedName(), is("eas:x"));
+        assertThat(((DefaultElement) in13.elements().get(0)).getText(), is("52.080357"));
+        assertTrue(((DefaultElement) in13.elements().get(1)).elements().isEmpty());
+        assertThat(((DefaultElement) in13.elements().get(1)).getQualifiedName(), is("eas:y"));
+        assertThat(((DefaultElement) in13.elements().get(1)).getText(), is("4.344110"));
+
+        assertThat(in14.elements().size(), is(2));
+        assertThat(in14.getQualifiedName(), is("eas:polygon-point"));
+        assertTrue(((DefaultElement) in14.elements().get(0)).elements().isEmpty());
+        assertThat(((DefaultElement) in14.elements().get(0)).getQualifiedName(), is("eas:x"));
+        assertThat(((DefaultElement) in14.elements().get(0)).getText(), is("52.080542"));
+        assertTrue(((DefaultElement) in14.elements().get(1)).elements().isEmpty());
+        assertThat(((DefaultElement) in14.elements().get(1)).getQualifiedName(), is("eas:y"));
+        assertThat(((DefaultElement) in14.elements().get(1)).getText(), is("4.344215"));
+
+        assertThat(in21.elements().size(), is(2));
+        assertThat(in21.getQualifiedName(), is("eas:polygon-point"));
+        assertTrue(((DefaultElement) in21.elements().get(0)).elements().isEmpty());
+        assertThat(((DefaultElement) in21.elements().get(0)).getQualifiedName(), is("eas:x"));
+        assertThat(((DefaultElement) in21.elements().get(0)).getText(), is("52.080542"));
+        assertTrue(((DefaultElement) in21.elements().get(1)).elements().isEmpty());
+        assertThat(((DefaultElement) in21.elements().get(1)).getQualifiedName(), is("eas:y"));
+        assertThat(((DefaultElement) in21.elements().get(1)).getText(), is("4.344215"));
+
+        assertThat(in22.elements().size(), is(2));
+        assertThat(in22.getQualifiedName(), is("eas:polygon-point"));
+        assertTrue(((DefaultElement) in22.elements().get(0)).elements().isEmpty());
+        assertThat(((DefaultElement) in22.elements().get(0)).getQualifiedName(), is("eas:x"));
+        assertThat(((DefaultElement) in22.elements().get(0)).getText(), is("52.080450"));
+        assertTrue(((DefaultElement) in22.elements().get(1)).elements().isEmpty());
+        assertThat(((DefaultElement) in22.elements().get(1)).getQualifiedName(), is("eas:y"));
+        assertThat(((DefaultElement) in22.elements().get(1)).getText(), is("4.344323"));
+
+        assertThat(in23.elements().size(), is(2));
+        assertThat(in23.getQualifiedName(), is("eas:polygon-point"));
+        assertTrue(((DefaultElement) in23.elements().get(0)).elements().isEmpty());
+        assertThat(((DefaultElement) in23.elements().get(0)).getQualifiedName(), is("eas:x"));
+        assertThat(((DefaultElement) in23.elements().get(0)).getText(), is("52.080357"));
+        assertTrue(((DefaultElement) in23.elements().get(1)).elements().isEmpty());
+        assertThat(((DefaultElement) in23.elements().get(1)).getQualifiedName(), is("eas:y"));
+        assertThat(((DefaultElement) in23.elements().get(1)).getText(), is("4.344110"));
+
+        assertThat(in24.elements().size(), is(2));
+        assertThat(in24.getQualifiedName(), is("eas:polygon-point"));
+        assertTrue(((DefaultElement) in24.elements().get(0)).elements().isEmpty());
+        assertThat(((DefaultElement) in24.elements().get(0)).getQualifiedName(), is("eas:x"));
+        assertThat(((DefaultElement) in24.elements().get(0)).getText(), is("52.080542"));
+        assertTrue(((DefaultElement) in24.elements().get(1)).elements().isEmpty());
+        assertThat(((DefaultElement) in24.elements().get(1)).getQualifiedName(), is("eas:y"));
+        assertThat(((DefaultElement) in24.elements().get(1)).getText(), is("4.344215"));
     }
 
     @Test

--- a/src/test/resources/output/example1.xml
+++ b/src/test/resources/output/example1.xml
@@ -49,7 +49,7 @@
         </eas:isPartOf>
     </emd:relation>
     <emd:rights>
-        <dct:accessRights>OPEN_ACCESS_FOR_REGISTERED_USERS</dct:accessRights>
+        <dct:accessRights eas:schemeId="common.dcterms.accessrights">OPEN_ACCESS_FOR_REGISTERED_USERS</dct:accessRights>
         <dct:license>http://opensource.org/licenses/BSD-2-Clause</dct:license>
     </emd:rights>
     <emd:audience>

--- a/src/test/resources/output/example2.xml
+++ b/src/test/resources/output/example2.xml
@@ -229,7 +229,7 @@
         </eas:spatial>
     </emd:coverage>
     <emd:rights>
-        <dct:accessRights>OPEN_ACCESS</dct:accessRights>
+        <dct:accessRights eas:schemeId="common.dcterms.accessrights">OPEN_ACCESS</dct:accessRights>
         <dct:rightsHolder>Houder van rechten</dct:rightsHolder>
     </emd:rights>
     <emd:audience>


### PR DESCRIPTION
Fix a couple of bugs in the DDM -> EMD transformation:

* `ISO3166/dcterms:spatial` was not parsed at all
* accessRights handler needs to add a `schemeId=common.dcterms.accessrights` to the `BasicString`
* the polygon must also be parsed without `internal` or `description` fields