### PR TITLE
EASY-1515: Handle ddm:description

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <name>Dans Dataset Metadata Library (DDM)</name>
     <inceptionYear>2014</inceptionYear>
     <properties>
-        <easy.schema.version>1.16.1</easy.schema.version>
+        <easy.schema.version>1.16.2</easy.schema.version>
         <easy.emd.version>3.7.1</easy.emd.version>
     </properties>
     <scm>

--- a/src/main/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdHandlerMap.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdHandlerMap.java
@@ -343,6 +343,7 @@ public class Ddm2EmdHandlerMap implements CrosswalkHandlerMap<EasyMetadata> {
         final BasicStringHandler descriptionHandler = new DescriptionHandler();
         map.put("/dc:description", descriptionHandler);
         map.put("/dcterms:description", descriptionHandler);
+        map.put("/ddm:description", descriptionHandler);
         // EasyMetadataImpl: EmdDescription emdDescription;
 
         final BasicStringHandler dcFormatHandler = new DcFormatHandler(false);

--- a/src/main/java/nl/knaw/dans/pf/language/ddm/handlermaps/NameSpace.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/handlermaps/NameSpace.java
@@ -23,7 +23,7 @@ public enum NameSpace {
     GML("gml", "http://www.opengis.net/gml", "http://schemas.opengis.net/gml/3.2.1/gml.xsd"), //
     DCX_DAI("dcx-dai", "http://easy.dans.knaw.nl/schemas/dcx/dai/", "http://easy.dans.knaw.nl/schemas/dcx/2017/09/dcx-dai.xsd"), //
     DCX_GML("dcx-gml", "http://easy.dans.knaw.nl/schemas/dcx/gml/", "http://easy.dans.knaw.nl/schemas/dcx/2016/dcx-gml.xsd"), //
-    DDM("ddm", "http://easy.dans.knaw.nl/schemas/md/ddm/", "http://easy.dans.knaw.nl/schemas/md/2018/02/ddm.xsd"), //
+    DDM("ddm", "http://easy.dans.knaw.nl/schemas/md/ddm/", "http://easy.dans.knaw.nl/schemas/md/2018/03/ddm.xsd"), //
     XSI("xsi", "http://www.w3.org/2001/XMLSchema-instance", "https://www.w3.org/2001/XMLSchema-instance"), //
     NARCIS_TYPE("narcis", "http://easy.dans.knaw.nl/schemas/vocab/narcis-type/", "http://easy.dans.knaw.nl/schemas/vocab/2015/narcis-type.xsd"), //
     IDENTIFIER_TYPE("id-type", "http://easy.dans.knaw.nl/schemas/vocab/identifier-type/", "http://easy.dans.knaw.nl/schemas/vocab/2017/09/identifier-type.xsd"), //

--- a/src/main/java/nl/knaw/dans/pf/language/ddm/handlermaps/NameSpace.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/handlermaps/NameSpace.java
@@ -21,7 +21,7 @@ public enum NameSpace {
     DCMITYPE("dcmitype", "http://purl.org/dc/dcmitype/", "http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcmitype.xsd"), //
     DCX("dcx", "http://easy.dans.knaw.nl/schemas/dcx/", "http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd"), //
     GML("gml", "http://www.opengis.net/gml", "http://schemas.opengis.net/gml/3.2.1/gml.xsd"), //
-    DCX_DAI("dcx-dai", "http://easy.dans.knaw.nl/schemas/dcx/dai/", "http://easy.dans.knaw.nl/schemas/dcx/2017/09/dcx-dai.xsd"), //
+    DCX_DAI("dcx-dai", "http://easy.dans.knaw.nl/schemas/dcx/dai/", "http://easy.dans.knaw.nl/schemas/dcx/2018/03/dcx-dai.xsd"), //
     DCX_GML("dcx-gml", "http://easy.dans.knaw.nl/schemas/dcx/gml/", "http://easy.dans.knaw.nl/schemas/dcx/2016/dcx-gml.xsd"), //
     DDM("ddm", "http://easy.dans.knaw.nl/schemas/md/ddm/", "http://easy.dans.knaw.nl/schemas/md/2018/03/ddm.xsd"), //
     XSI("xsi", "http://www.w3.org/2001/XMLSchema-instance", "https://www.w3.org/2001/XMLSchema-instance"), //

--- a/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
@@ -17,6 +17,7 @@ package nl.knaw.dans.pf.language.ddm.api;
 
 import nl.knaw.dans.pf.language.emd.EasyMetadata;
 import nl.knaw.dans.pf.language.emd.binding.EmdMarshaller;
+import nl.knaw.dans.pf.language.emd.types.EmdConstants;
 import nl.knaw.dans.pf.language.xml.crosswalk.CrosswalkException;
 import nl.knaw.dans.pf.language.xml.exc.XMLSerializationException;
 import org.dom4j.tree.DefaultElement;
@@ -58,6 +59,110 @@ public class Ddm2EmdCrosswalkTest {
     }
 
     @Test
+    public void dcxIsniAuthor() throws Exception {
+        // @formatter:off
+        String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM"
+            + "  xmlns:dc='http://purl.org/dc/elements/1.1/'"
+            + "  xmlns:dcx-dai='http://easy.dans.knaw.nl/schemas/dcx/dai/'"
+            + "  xmlns:ddm='http://easy.dans.knaw.nl/schemas/md/ddm/'"
+            + "  xmlns:dcterms='http://purl.org/dc/terms/'"
+            + "  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>"
+            + "  <ddm:profile>"
+            + "    <dcx-dai:creatorDetails>"
+            + "      <dcx-dai:author>"
+             + "      <dcx-dai:initials>X.I.</dcx-dai:initials>"
+            + "       <dcx-dai:surname>lastname</dcx-dai:surname>"
+            + "       <dcx-dai:ISNI>ISNI:000000012281955X</dcx-dai:ISNI>"
+            + "     </dcx-dai:author>"
+            + "   </dcx-dai:creatorDetails>"
+            + "  </ddm:profile>"
+            + "</ddm:DDM>";
+        // @formatter:on
+
+        DefaultElement top = firstEmdElementFrom(ddm);
+        assertThat(top.getQualifiedName(), is("emd:creator"));
+
+        DefaultElement sub = (DefaultElement) top.elements().get(0);
+        assertThat(sub.getQualifiedName(), is("eas:creator"));
+
+        List<DefaultElement> children = (List<DefaultElement>) sub.elements();
+
+        // we expect it to ignore the ISNI
+        assertThat(children.size(), is(2));
+        assertThat(children.get(0).getText(), is("X.I."));
+        assertThat(children.get(0).getName(), is("initials"));
+        assertThat(children.get(1).getText(), is("lastname"));
+    }
+
+    @Test
+    public void dcxDaiAuthor() throws Exception {
+        // @formatter:off
+        String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM"
+            + "  xmlns:dc='http://purl.org/dc/elements/1.1/'"
+            + "  xmlns:dcx-dai='http://easy.dans.knaw.nl/schemas/dcx/dai/'"
+            + "  xmlns:ddm='http://easy.dans.knaw.nl/schemas/md/ddm/'"
+            + "  xmlns:dcterms='http://purl.org/dc/terms/'"
+            + "  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>"
+            + "  <ddm:profile>"
+            + "    <dcx-dai:creatorDetails>"
+            + "      <dcx-dai:author>"
+            + "      <dcx-dai:initials>X.I.</dcx-dai:initials>"
+            + "       <dcx-dai:surname>lastname</dcx-dai:surname>"
+            + "       <dcx-dai:DAI>info:eu-repo/dai/nl/9876543216</dcx-dai:DAI>"
+            + "     </dcx-dai:author>"
+            + "   </dcx-dai:creatorDetails>"
+            + "  </ddm:profile>"
+            + "</ddm:DDM>";
+        // @formatter:on
+
+        DefaultElement top = firstEmdElementFrom(ddm);
+        assertThat(top.getQualifiedName(), is("emd:creator"));
+
+        DefaultElement sub = (DefaultElement) top.elements().get(0);
+        assertThat(sub.getQualifiedName(), is("eas:creator"));
+
+        List<DefaultElement> children = (List<DefaultElement>) sub.elements();
+
+        // we expect it to convert the DAI
+        assertThat(children.size(), is(3));
+        assertThat(children.get(0).getText(), is("X.I."));
+        assertThat(children.get(0).getName(), is("initials"));
+        assertThat(children.get(1).getText(), is("lastname"));
+        assertThat(children.get(2).attributeCount(), is(1));
+        assertThat(children.get(2).attribute("scheme").getValue(), is(EmdConstants.SCHEME_DAI));
+        assertThat(children.get(2).getText(), is("info:eu-repo/dai/nl/9876543216"));
+    }
+
+    @Test
+    public void ddmDescription() throws Exception {
+        // @formatter:off
+        String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM"
+            + "  xmlns:dc='http://purl.org/dc/elements/1.1/'"
+            + "  xmlns:ddm='http://easy.dans.knaw.nl/schemas/md/ddm/'"
+            + "  xmlns:dcterms='http://purl.org/dc/terms/'"
+            + "  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>"
+            + "  <ddm:profile>"
+            + "    <ddm:description ddm:descriptionType='Abstract'>abstract</ddm:description>"
+            + "    <dcterms:description>beschrijving</dcterms:description>"
+            + "  </ddm:profile>"
+            + "</ddm:DDM>";
+        // @formatter:on
+
+        DefaultElement top = firstEmdElementFrom(ddm);
+        assertThat(top.getQualifiedName(), is("emd:description"));
+        assertThat(top.elements().size(), is(2));
+
+        DefaultElement firstSub = (DefaultElement) top.elements().get(0);
+        assertThat(firstSub.getQualifiedName(), is("dc:description"));
+        assertThat(firstSub.getText(), is("abstract"));
+        assertThat(firstSub.attributeCount(), is(0));
+        DefaultElement secondSub = (DefaultElement) top.elements().get(1);
+        assertThat(secondSub.getQualifiedName(), is("dc:description"));
+        assertThat(secondSub.getText(), is("beschrijving"));
+        assertThat(secondSub.attributeCount(), is(0));
+    }
+
+    @Test
     public void identifierWithIdTypeEDNA() throws Exception {
         // @formatter:off
         String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM"
@@ -83,6 +188,7 @@ public class Ddm2EmdCrosswalkTest {
         assertThat(sub.attribute("scheme").getValue(), is("eDNA-project"));
     }
 
+    @Test
     public void alternativeTitle() throws Exception {
         // @formatter:off
         String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM"

--- a/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
@@ -134,7 +134,7 @@ public class Ddm2EmdCrosswalkTest {
     }
 
     @Test
-    public void ddmDescription() throws Exception {
+    public void ddmDescriptionWithRequiredDescriptionType() throws Exception {
         // @formatter:off
         String ddm = "<?xml version='1.0' encoding='utf-8'?><ddm:DDM"
             + "  xmlns:dc='http://purl.org/dc/elements/1.1/'"

--- a/src/test/resources/input/ddm.xml
+++ b/src/test/resources/input/ddm.xml
@@ -28,13 +28,14 @@
 	xmlns:id-type="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/">
 	<ddm:profile>
         <dc:title>The title of the Dataset</dc:title>
-        <dcterms:description>The Dataset abstract</dcterms:description>
+        <ddm:description descriptionType='Abstract'>The Dataset abstract</ddm:description>
         <dcx-dai:creatorDetails>
             <dcx-dai:author>
                 <dcx-dai:titles></dcx-dai:titles>
                 <dcx-dai:initials>I</dcx-dai:initials>
                 <dcx-dai:insertions></dcx-dai:insertions>
                 <dcx-dai:surname>Lastname</dcx-dai:surname>
+                <dcx-dai:ISNI>ISNI:12341234123x</dcx-dai:ISNI>
                 <dcx-dai:organization>
                     <dcx-dai:name xml:lang="en">DANS</dcx-dai:name>
                 </dcx-dai:organization>


### PR DESCRIPTION
fixes EASY-1515

#### When applied it will
* Handle ddm:description, ignore @descriptionType
* Ignore ISNI/ORCID when converting to EMD
* Upgrade easy-schema to 1.16.2

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ---
easy-schema                      | [v1.16.2](https://github.com/DANS-KNAW/easy-schema/releases/tag/v1.16.2)     | 
