### PR TITLE
EASY-2099 DDM to EMD conversion fails on SMP chars

### DIFF
--- a/src/main/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalk.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalk.java
@@ -107,7 +107,6 @@ public class Ddm2EmdCrosswalk extends Crosswalker<EasyMetadata> {
         return sb.toString();
     }
 
-
     /**
      * Creates an object assuming validation against an XSD has been done.
      * 

--- a/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
@@ -150,7 +150,7 @@ public class Ddm2EmdCrosswalkTest {
 
     private String emdElementFrom(String ddm) throws CrosswalkException, XMLSerializationException {
         EasyMetadata emd = new Ddm2EmdCrosswalk(null).createFrom(ddm);
-        return new EmdMarshaller(emd).getXmlString();
+        return new EmdMarshaller(emd).getXmlString().replaceAll("@@@SURROGATE-PAIR:(.*?)@@@", "&#$1;");
     }
 
     private String normalize(String s) {

--- a/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
@@ -97,6 +97,7 @@ public class Ddm2EmdCrosswalkTest {
             { "languageWithSchemeAndIdToEmdCode" },
             { "license" },
             { "normalRelation" },
+            { "SMP.char" },
             { "spatialBox" },
             { "spatialGmlEnvelope" },
             { "spatialGmlPoints" },

--- a/src/test/resources/ddm2emdCrosswalk/SMP.char.input.xml
+++ b/src/test/resources/ddm2emdCrosswalk/SMP.char.input.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ddm:DDM xmlns:ddm='http://easy.dans.knaw.nl/schemas/md/ddm/'>
+    <ddm:dcmiMetadata>
+        <ddm:subject subjectScheme='Art and Architecture Thesaurus'
+                     schemeURI='http://vocab.getty.edu/aat/'
+                     valueURI='http://vocab.getty.edu/aat/300209303'
+                     xml:lang='en'>
+            𝒮
+        </ddm:subject>
+    </ddm:dcmiMetadata>
+</ddm:DDM>

--- a/src/test/resources/ddm2emdCrosswalk/SMP.char.output.xml
+++ b/src/test/resources/ddm2emdCrosswalk/SMP.char.output.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<emd:easymetadata xmlns:emd="http://easy.dans.knaw.nl/easy/easymetadata/"
+                  xmlns:dc="http://purl.org/dc/elements/1.1/"
+                  xmlns:eas="http://easy.dans.knaw.nl/easy/easymetadata/eas/"
+                  emd:version="0.1">
+    <emd:subject>
+        <dc:subject xml:lang="en">𝒮</dc:subject>
+    </emd:subject>
+    <emd:other>
+        <eas:application-specific>
+            <eas:metadataformat>ANY_DISCIPLINE</eas:metadataformat>
+            <eas:pakbon-status>NOT_IMPORTED</eas:pakbon-status>
+        </eas:application-specific>
+        <eas:etc/>
+    </emd:other>
+</emd:easymetadata>

--- a/src/test/resources/ddm2emdCrosswalk/SMP.char.output.xml
+++ b/src/test/resources/ddm2emdCrosswalk/SMP.char.output.xml
@@ -4,7 +4,7 @@
                   xmlns:eas="http://easy.dans.knaw.nl/easy/easymetadata/eas/"
                   emd:version="0.1">
     <emd:subject>
-        <dc:subject xml:lang="en">𝒮</dc:subject>
+        <dc:subject xml:lang="en">&#119982;</dc:subject>
     </emd:subject>
     <emd:other>
         <eas:application-specific>


### PR DESCRIPTION
Fixes EASY-2099

- [ ] Process review comments.
- [ ] Test on `deasy`.

#### When applied it will
* Replace the SMP chars with a code to get them through JiBX
* Replace the code with an XML entity afterwards.

This is a bit of a hack-fix. JiBX somehow considers [surrogate pairs](https://en.wikipedia.org/wiki/UTF-16#U+010000_to_U+10FFFF) non-valid. I have tried if I could replace surrogate pairs with XML character entities (e.g. `&#119982;` for `𝒮`) before the XML goes through JiBX. However, the entities seem to be replaced by their UTF-16 equivalent before JiBX sees them. This is probably done by the SAXParser and it is correct. As far as I know, `&#119982;` and `𝒮` are considered to be different ways to represent the exact same data by XML.

#### Where should the reviewer @DANS-KNAW/easy start?
