### PR TITLE
EASY-2099 Conversion to EMD fails on surrogate pairs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,11 @@
             <version>2.16</version>
         </dependency>
         <dependency>
+            <groupId>org.jibx</groupId>
+            <artifactId>jibx-run</artifactId>
+            <version>1.2.4.6-DANS</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.jibx</groupId>
             <artifactId>jibx-run</artifactId>
-            <version>1.2.4.6-DANS</version>
+            <version>1.2.4.7-DANS</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
@@ -98,6 +98,7 @@ public class Ddm2EmdCrosswalkTest {
             { "license" },
             { "normalRelation" },
             { "SMP.char" },
+            { "SMP.char.many" },
             { "spatialBox" },
             { "spatialGmlEnvelope" },
             { "spatialGmlPoints" },

--- a/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
@@ -28,10 +28,12 @@ import org.junit.runners.Parameterized.Parameters;
 
 import java.io.File;
 import java.net.URISyntaxException;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collection;
 
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -47,6 +49,7 @@ public class Ddm2EmdCrosswalkTest {
         testFilesDirectory = new File(Ddm2EmdCrosswalkTest.class.getResource("/ddm2emdCrosswalk").toURI());
 
         checkTestDataConsistency(testFilesDirectory);
+        assertEquals(Charset.forName("UTF-8"), Charset.defaultCharset());
     }
 
     private static void checkTestDataConsistency(File testFiles) {

--- a/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
@@ -49,7 +49,7 @@ public class Ddm2EmdCrosswalkTest {
         testFilesDirectory = new File(Ddm2EmdCrosswalkTest.class.getResource("/ddm2emdCrosswalk").toURI());
 
         checkTestDataConsistency(testFilesDirectory);
-        assertEquals(Charset.forName("UTF-8"), Charset.defaultCharset());
+        assertEquals("For these test to run UTF-8 MUST be the default charset. Configure this in your OS (en_US.UTF-8 on the Mac)", Charset.forName("UTF-8"), Charset.defaultCharset());
     }
 
     private static void checkTestDataConsistency(File testFiles) {

--- a/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
@@ -97,6 +97,7 @@ public class Ddm2EmdCrosswalkTest {
             { "languageWithSchemeAndIdToEmdCode" },
             { "license" },
             { "normalRelation" },
+            { "SMP.char" },
             { "spatialBox" },
             { "spatialGmlEnvelope" },
             { "spatialGmlPoints" },

--- a/src/test/resources/ddm2emdCrosswalk/SMP.char.input.xml
+++ b/src/test/resources/ddm2emdCrosswalk/SMP.char.input.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ddm:DDM xmlns:ddm='http://easy.dans.knaw.nl/schemas/md/ddm/'>
+    <ddm:dcmiMetadata>
+        <ddm:subject subjectScheme='Art and Architecture Thesaurus'
+                     schemeURI='http://vocab.getty.edu/aat/'
+                     valueURI='http://vocab.getty.edu/aat/300209303'
+                     xml:lang='en'>
+            𝒮
+        </ddm:subject>
+    </ddm:dcmiMetadata>
+</ddm:DDM>

--- a/src/test/resources/ddm2emdCrosswalk/SMP.char.many.input.xml
+++ b/src/test/resources/ddm2emdCrosswalk/SMP.char.many.input.xml
@@ -5,7 +5,7 @@
                      schemeURI='http://vocab.getty.edu/aat/'
                      valueURI='http://vocab.getty.edu/aat/300209303'
                      xml:lang='en'>
-            𓁨𓃵𓄟 𠁆𠁟 🜵🝳🜁🜂🜄🜐
+            𓁨𓃵𓄟 𠁆𠁟 🜵🝳🜁some other text🜂🜄🜐
         </ddm:subject>
     </ddm:dcmiMetadata>
 </ddm:DDM>

--- a/src/test/resources/ddm2emdCrosswalk/SMP.char.many.input.xml
+++ b/src/test/resources/ddm2emdCrosswalk/SMP.char.many.input.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ddm:DDM xmlns:ddm='http://easy.dans.knaw.nl/schemas/md/ddm/'>
+    <ddm:dcmiMetadata>
+        <ddm:subject subjectScheme='Art and Architecture Thesaurus'
+                     schemeURI='http://vocab.getty.edu/aat/'
+                     valueURI='http://vocab.getty.edu/aat/300209303'
+                     xml:lang='en'>
+            𓁨𓃵𓄟 𠁆𠁟 🜵🝳🜁🜂🜄🜐
+        </ddm:subject>
+    </ddm:dcmiMetadata>
+</ddm:DDM>

--- a/src/test/resources/ddm2emdCrosswalk/SMP.char.many.output.xml
+++ b/src/test/resources/ddm2emdCrosswalk/SMP.char.many.output.xml
@@ -4,7 +4,7 @@
                   xmlns:eas="http://easy.dans.knaw.nl/easy/easymetadata/eas/"
                   emd:version="0.1">
     <emd:subject>
-        <dc:subject xml:lang="en">𝒮</dc:subject>
+        <dc:subject xml:lang="en">𓁨𓃵𓄟 𠁆𠁟 🜵🝳🜁🜂🜄🜐</dc:subject>
     </emd:subject>
     <emd:other>
         <eas:application-specific>

--- a/src/test/resources/ddm2emdCrosswalk/SMP.char.many.output.xml
+++ b/src/test/resources/ddm2emdCrosswalk/SMP.char.many.output.xml
@@ -4,7 +4,7 @@
                   xmlns:eas="http://easy.dans.knaw.nl/easy/easymetadata/eas/"
                   emd:version="0.1">
     <emd:subject>
-        <dc:subject xml:lang="en">𓁨𓃵𓄟 𠁆𠁟 🜵🝳🜁🜂🜄🜐</dc:subject>
+        <dc:subject xml:lang="en">𓁨𓃵𓄟 𠁆𠁟 🜵🝳🜁some other text🜂🜄🜐</dc:subject>
     </emd:subject>
     <emd:other>
         <eas:application-specific>

--- a/src/test/resources/ddm2emdCrosswalk/SMP.char.output.xml
+++ b/src/test/resources/ddm2emdCrosswalk/SMP.char.output.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<emd:easymetadata xmlns:emd="http://easy.dans.knaw.nl/easy/easymetadata/"
+                  xmlns:dc="http://purl.org/dc/elements/1.1/"
+                  xmlns:eas="http://easy.dans.knaw.nl/easy/easymetadata/eas/"
+                  emd:version="0.1">
+    <emd:subject>
+        <dc:subject xml:lang="en">&#119982;</dc:subject>
+    </emd:subject>
+    <emd:other>
+        <eas:application-specific>
+            <eas:metadataformat>ANY_DISCIPLINE</eas:metadataformat>
+            <eas:pakbon-status>NOT_IMPORTED</eas:pakbon-status>
+        </eas:application-specific>
+        <eas:etc/>
+    </emd:other>
+</emd:easymetadata>


### PR DESCRIPTION
Fixes EASY-2099

#### When applied it will
* Make sure `easy-ddm` depends on a patched version of `jbix-run` that can handle surrogate pairs.

#### Where should the reviewer @DANS-KNAW/easy start?

