### PR TITLE
EASY-2159: Add instructions for reuse field to end as remark

### DIFF
--- a/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/DescriptionHandler.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/DescriptionHandler.java
@@ -26,14 +26,12 @@ public class DescriptionHandler extends BasicStringHandler {
   protected void finishElement(final String uri, final String localName) throws SAXException {
     final BasicString basicString = createBasicString(uri, localName);
     String desciptionType = getAttribute("", "descriptionType");
-    boolean isTechnicalDescription = desciptionType == null ? false : desciptionType.equals("TechnicalInfo");
-    if (basicString == null) {
-    }
-    else if (isTechnicalDescription) {
-      getTarget().getEmdOther().getEasRemarks().add(new BasicRemark("Instructions for Reuse: " + basicString.getValue()));
-    }
-    else {
-      getTarget().getEmdDescription().getDcDescription().add(basicString);
+    boolean isTechnicalDescription = desciptionType != null && desciptionType.equals("TechnicalInfo");
+    if (basicString != null) {
+      if (isTechnicalDescription)
+        getTarget().getEmdOther().getEasRemarks().add(new BasicRemark("Instructions for Reuse: " + basicString.getValue()));
+      else
+        getTarget().getEmdDescription().getDcDescription().add(basicString);
     }
   }
 }

--- a/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/DescriptionHandler.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/DescriptionHandler.java
@@ -16,15 +16,24 @@
 package nl.knaw.dans.pf.language.ddm.handlers;
 
 import nl.knaw.dans.pf.language.ddm.handlertypes.BasicStringHandler;
+import nl.knaw.dans.pf.language.emd.types.BasicRemark;
 import nl.knaw.dans.pf.language.emd.types.BasicString;
-
 import org.xml.sax.SAXException;
 
 public class DescriptionHandler extends BasicStringHandler {
-    @Override
-    protected void finishElement(final String uri, final String localName) throws SAXException {
-        final BasicString basicString = createBasicString(uri, localName);
-        if (basicString != null)
-            getTarget().getEmdDescription().getDcDescription().add(basicString);
+
+  @Override
+  protected void finishElement(final String uri, final String localName) throws SAXException {
+    final BasicString basicString = createBasicString(uri, localName);
+    String desciptionType = getAttribute("", "descriptionType");
+    boolean isTechnicalDescription = desciptionType == null ? false : desciptionType.equals("TechnicalInfo");
+    if (basicString == null) {
     }
+    else if (isTechnicalDescription) {
+      getTarget().getEmdOther().getEasRemarks().add(new BasicRemark("Instructions for Reuse: " + basicString.getValue()));
+    }
+    else {
+      getTarget().getEmdDescription().getDcDescription().add(basicString);
+    }
+  }
 }

--- a/src/test/resources/ddm2emdCrosswalk/ddmDescriptionWithRequiredDescriptionType.input.xml
+++ b/src/test/resources/ddm2emdCrosswalk/ddmDescriptionWithRequiredDescriptionType.input.xml
@@ -3,6 +3,7 @@
          xmlns:dcterms='http://purl.org/dc/terms/'>
     <ddm:profile>
         <ddm:description ddm:descriptionType='Abstract'>abstract</ddm:description>
+        <ddm:description descriptionType="TechnicalInfo">remark1</ddm:description>
         <dcterms:description>beschrijving</dcterms:description>
     </ddm:profile>
 </ddm:DDM>

--- a/src/test/resources/ddm2emdCrosswalk/ddmDescriptionWithRequiredDescriptionType.output.xml
+++ b/src/test/resources/ddm2emdCrosswalk/ddmDescriptionWithRequiredDescriptionType.output.xml
@@ -6,6 +6,7 @@
         <dc:description>beschrijving</dc:description>
     </emd:description>
     <emd:other>
+        <eas:remark>Instructions for Reuse: remark1</eas:remark>
         <eas:application-specific>
             <eas:metadataformat>ANY_DISCIPLINE</eas:metadataformat>
             <eas:pakbon-status>NOT_IMPORTED</eas:pakbon-status>


### PR DESCRIPTION
fixes EASY-2159

#### When applied it will
* Add instructions for reuse field to end as remark
#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

build easy-ddm, stage-dataset with new ddm dependency, ingest-flow with new stage dependency
and the master of deposit-api. Than upload a deposit and don't forget to fill in the instructions for reuse field.