### PR TITLE
EASY-2206: check for prefix in 'technical-info' description

### DIFF
--- a/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/DescriptionHandler.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/DescriptionHandler.java
@@ -25,10 +25,16 @@ public class DescriptionHandler extends BasicStringHandler {
   protected void finishElement(final String uri, final String localName) throws SAXException {
     final BasicString basicString = createBasicString(uri, localName);
     String desciptionType = getAttribute("", "descriptionType");
-    boolean isTechnicalDescription = desciptionType != null && desciptionType.equals("TechnicalInfo");
+
     if (basicString != null) {
-      if (isTechnicalDescription)
-        basicString.setValue("Instructions for Reuse: " + basicString.getValue());
+      String prefix = "Instructions for Reuse: ";
+      String value = basicString.getValue();
+      boolean isTechnicalDescription = desciptionType != null && desciptionType.equals("TechnicalInfo");
+      boolean hasPrefix = value.toLowerCase().startsWith(prefix.toLowerCase());
+
+      if (isTechnicalDescription && !hasPrefix)
+        basicString.setValue(prefix + value);
+
       getTarget().getEmdDescription().getDcDescription().add(basicString);
     }
   }

--- a/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/DescriptionHandler.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/handlers/DescriptionHandler.java
@@ -24,11 +24,11 @@ public class DescriptionHandler extends BasicStringHandler {
   @Override
   protected void finishElement(final String uri, final String localName) throws SAXException {
     final BasicString basicString = createBasicString(uri, localName);
-    String desciptionType = getAttribute("", "descriptionType");
 
     if (basicString != null) {
       String prefix = "Instructions for Reuse: ";
       String value = basicString.getValue();
+      String desciptionType = getAttribute("", "descriptionType");
       boolean isTechnicalDescription = desciptionType != null && desciptionType.equals("TechnicalInfo");
       boolean hasPrefix = value.toLowerCase().startsWith(prefix.toLowerCase());
 

--- a/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
@@ -86,6 +86,7 @@ public class Ddm2EmdCrosswalkTest {
             { "dcxIsniAuthor" },
             { "ddmAccessRight" },
             { "ddmDescriptionWithRequiredDescriptionType" },
+            { "ddmDescriptionWithRequiredDescriptionTypeAndPrefix" },
             { "ddmSubject" },
             { "ddmTemporal" },
             { "formatWithSchemeAndId" },

--- a/src/test/resources/ddm2emdCrosswalk/ddmDescriptionWithRequiredDescriptionTypeAndPrefix.input.xml
+++ b/src/test/resources/ddm2emdCrosswalk/ddmDescriptionWithRequiredDescriptionTypeAndPrefix.input.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ddm:DDM xmlns:ddm='http://easy.dans.knaw.nl/schemas/md/ddm/'
+         xmlns:dcterms='http://purl.org/dc/terms/'>
+    <ddm:profile>
+        <ddm:description descriptionType='Abstract'>abstract</ddm:description>
+        <ddm:description descriptionType="TechnicalInfo">Instructions for Reuse: remark1</ddm:description>
+        <dcterms:description>beschrijving</dcterms:description>
+    </ddm:profile>
+</ddm:DDM>

--- a/src/test/resources/ddm2emdCrosswalk/ddmDescriptionWithRequiredDescriptionTypeAndPrefix.output.xml
+++ b/src/test/resources/ddm2emdCrosswalk/ddmDescriptionWithRequiredDescriptionTypeAndPrefix.output.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<emd:easymetadata xmlns:emd="http://easy.dans.knaw.nl/easy/easymetadata/"
+                  xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:eas="http://easy.dans.knaw.nl/easy/easymetadata/eas/" emd:version="0.1">
+    <emd:description>
+        <dc:description>abstract</dc:description>
+        <dc:description>Instructions for Reuse: remark1</dc:description>
+        <dc:description>beschrijving</dc:description>
+    </emd:description>
+    <emd:other>
+        <eas:application-specific>
+            <eas:metadataformat>ANY_DISCIPLINE</eas:metadataformat>
+            <eas:pakbon-status>NOT_IMPORTED</eas:pakbon-status>
+        </eas:application-specific>
+        <eas:etc/>
+    </emd:other>
+</emd:easymetadata>


### PR DESCRIPTION
fixes EASY-2206

#### When applied it will
* check for a prefix in a 'technical-info' description before adding the prefix

@DANS-KNAW/easy for review