### PR TITLE
EASY-2205: upgrade easy-schema dependency from 2.1.8 to 2.1.10 and easy-schema-examples dependency from 1.0.2 to 1.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <inceptionYear>2014</inceptionYear>
     <properties>
         <easy.schema.version>2.1.10</easy.schema.version>
-        <easy.schema.examples.version>1.0.4</easy.schema.examples.version>
+        <easy.schema.examples.version>1.0.3</easy.schema.examples.version>
         <easy.emd.version>3.8.0</easy.emd.version>
     </properties>
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
     <name>Dans Dataset Metadata Library (DDM)</name>
     <inceptionYear>2014</inceptionYear>
     <properties>
-        <easy.schema.version>2.1.8</easy.schema.version>
-        <easy.schema.examples.version>1.0.2</easy.schema.examples.version>
+        <easy.schema.version>2.1.10</easy.schema.version>
+        <easy.schema.examples.version>1.0.4</easy.schema.examples.version>
         <easy.emd.version>3.8.0</easy.emd.version>
     </properties>
     <scm>

--- a/src/main/java/nl/knaw/dans/pf/language/ddm/handlermaps/NameSpace.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/handlermaps/NameSpace.java
@@ -23,7 +23,7 @@ public enum NameSpace {
     GML("gml", "http://www.opengis.net/gml", "http://schemas.opengis.net/gml/3.2.1/gml.xsd"), //
     DCX_DAI("dcx-dai", "http://easy.dans.knaw.nl/schemas/dcx/dai/", "https://easy.dans.knaw.nl/schemas/dcx/2019/01/dcx-dai.xsd"), //
     DCX_GML("dcx-gml", "http://easy.dans.knaw.nl/schemas/dcx/gml/", "https://easy.dans.knaw.nl/schemas/dcx/2016/dcx-gml.xsd"), //
-    DDM("ddm", "http://easy.dans.knaw.nl/schemas/md/ddm/", "https://easy.dans.knaw.nl/schemas/md/2019/01/ddm.xsd"), //
+    DDM("ddm", "http://easy.dans.knaw.nl/schemas/md/ddm/", "https://easy.dans.knaw.nl/schemas/md/2019/07/ddm.xsd"), //
     XSI("xsi", "http://www.w3.org/2001/XMLSchema-instance", "https://www.w3.org/2001/XMLSchema-instance"), //
     NARCIS_TYPE("narcis", "http://easy.dans.knaw.nl/schemas/vocab/narcis-type/", "https://easy.dans.knaw.nl/schemas/vocab/2019/01/narcis-type.xsd"), //
     IDENTIFIER_TYPE("id-type", "http://easy.dans.knaw.nl/schemas/vocab/identifier-type/", "https://easy.dans.knaw.nl/schemas/vocab/2017/09/identifier-type.xsd"), //


### PR DESCRIPTION
fixes EASY-2205

#### When applied it will
* upgrade easy-schema dependency from 2.1.8 to 2.1.10
* upgrade easy-schema-examples dependency from 1.0.2 to 1.0.4

@DANS-KNAW/easy for review

#### TODO
* [x] merge and deploy https://github.com/DANS-KNAW/easy-schema/pull/71
* [x] merge and deploy https://github.com/DANS-KNAW/easy-schema-examples/pull/5