### PR TITLE
Changed the dependency to 'easy-schema as a jar'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <inceptionYear>2014</inceptionYear>
     <properties>
         <easy.schema.version>3.0.1</easy.schema.version>
-        <easy.schema.examples.version>1.0.4</easy.schema.examples.version>
+        <easy.schema.examples.version>2.0.0</easy.schema.examples.version>
         <easy.emd.version>3.8.0</easy.emd.version>
     </properties>
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <inceptionYear>2014</inceptionYear>
     <properties>
         <easy.schema.version>3.0.0-SNAPSHOT</easy.schema.version>
-        <easy.schema.examples.version>1.0.3</easy.schema.examples.version>
+        <easy.schema.examples.version>1.0.4-SNAPSHOT</easy.schema.examples.version>
         <easy.emd.version>3.8.0</easy.emd.version>
     </properties>
     <scm>
@@ -154,7 +154,6 @@
                                     <groupId>nl.knaw.dans.easy</groupId>
                                     <artifactId>easy-schema-examples</artifactId>
                                     <version>${easy.schema.examples.version}</version>
-                                    <type>tar.gz</type>
                                     <outputDirectory>${project.build.directory}/easy-schema-examples</outputDirectory>
                                 </artifactItem>
                             </artifactItems>

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
     <name>DANS Dataset Metadata Library (DDM)</name>
     <inceptionYear>2014</inceptionYear>
     <properties>
-        <easy.schema.version>3.0.0-SNAPSHOT</easy.schema.version>
-        <easy.schema.examples.version>1.0.4-SNAPSHOT</easy.schema.examples.version>
+        <easy.schema.version>3.0.1</easy.schema.version>
+        <easy.schema.examples.version>1.0.4</easy.schema.examples.version>
         <easy.emd.version>3.8.0</easy.emd.version>
     </properties>
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -26,10 +26,10 @@
     <groupId>nl.knaw.dans.easy</groupId>
     <artifactId>ddm</artifactId>
     <version>3.8.8-SNAPSHOT</version>
-    <name>Dans Dataset Metadata Library (DDM)</name>
+    <name>DANS Dataset Metadata Library (DDM)</name>
     <inceptionYear>2014</inceptionYear>
     <properties>
-        <easy.schema.version>2.1.10</easy.schema.version>
+        <easy.schema.version>3.0.0-SNAPSHOT</easy.schema.version>
         <easy.schema.examples.version>1.0.3</easy.schema.examples.version>
         <easy.emd.version>3.8.0</easy.emd.version>
     </properties>
@@ -148,7 +148,6 @@
                                     <groupId>nl.knaw.dans.easy</groupId>
                                     <artifactId>easy-schema</artifactId>
                                     <version>${easy.schema.version}</version>
-                                    <type>tar.gz</type>
                                     <outputDirectory>${project.build.directory}/easy-schema</outputDirectory>
                                 </artifactItem>
                                 <artifactItem>
@@ -158,7 +157,6 @@
                                     <type>tar.gz</type>
                                     <outputDirectory>${project.build.directory}/easy-schema-examples</outputDirectory>
                                 </artifactItem>
-
                             </artifactItems>
                         </configuration>
                     </execution>


### PR DESCRIPTION
NO JIRA.

#### When applied it will
* Change the dependency to `easy-schema` to use easy-schema as a jar and no longer as a tgz.

#### Before merging
* [x] merge https://github.com/DANS-KNAW/easy-schema/pull/75
* [x] release `easy-schema` v3.0.1
* [x] set this as the version in this `pom.xml`
* [x] merge https://github.com/DANS-KNAW/easy-schema-examples/pull/8
* [x] release `easy-schema-examples` v2.0.0
* [x] set this as the version in this `pom.xml`

#### Where should the reviewer @DANS-KNAW/easy start?
the pom

#### Related PRs
https://github.com/DANS-KNAW/easy-schema/pull/75
