### PR TITLE
EASY-2362: let a DAI be parsed correctly in AuthorDetailsHandler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <inceptionYear>2014</inceptionYear>
     <properties>
         <easy.schema.version>3.0.2</easy.schema.version>
-        <easy.schema.examples.version>2.0.0</easy.schema.examples.version>
+        <easy.schema.examples.version>2.0.1</easy.schema.examples.version>
         <easy.emd.version>3.8.0</easy.emd.version>
     </properties>
     <scm>

--- a/src/main/java/nl/knaw/dans/pf/language/ddm/handlertypes/AuthorDetailsHandler.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/handlertypes/AuthorDetailsHandler.java
@@ -37,8 +37,6 @@ public abstract class AuthorDetailsHandler extends DaiAuthorHandler {
                 author.setInitials(value);
             else if ("surname".equals(localName))
                 author.setSurname(value);
-            else if ("DAI".equals(localName))
-                author.setEntityId(value, "DAI");
             else if ("titles".equals(localName))
                 author.setTitle(value);
             else if ("name".equals(localName)/* part of organization */)

--- a/src/main/java/nl/knaw/dans/pf/language/ddm/handlertypes/DaiAuthorHandler.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/handlertypes/DaiAuthorHandler.java
@@ -46,7 +46,7 @@ public abstract class DaiAuthorHandler extends CrosswalkHandler<EasyMetadata> {
             author.setIdentificationSystem(toURI(idSys));
         } else {
             author.setEntityId(value, EmdConstants.SCHEME_DAI);
-            author.setIdentificationSystem(toURI("info:eu-repo/dai/nl/"));
+            author.setIdentificationSystem(toURI(DAI.DAI_NAMESPACE));
         }
         if (!DAI.isValid(author.getEntityId())) {
             error("invalid DAI " + author.getEntityId());

--- a/src/main/java/nl/knaw/dans/pf/language/ddm/handlertypes/DaiAuthorHandler.java
+++ b/src/main/java/nl/knaw/dans/pf/language/ddm/handlertypes/DaiAuthorHandler.java
@@ -37,7 +37,7 @@ public abstract class DaiAuthorHandler extends CrosswalkHandler<EasyMetadata> {
         return setDAI(author, attribute);
     }
 
-    protected Author setDAI(final Author author, final String value) throws SAXException {
+    Author setDAI(final Author author, final String value) throws SAXException {
         if (value.startsWith("info")) {
             final String[] strings = value.split("/");
             final String entityId = strings[strings.length - 1];

--- a/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdCrosswalkTest.java
@@ -151,7 +151,7 @@ public class Ddm2EmdCrosswalkTest {
         String actualEmd = normalize(FileUtils.readFileToString(emdFile));
         String expectedEmd = normalize(emdElementFrom(ddm));
 
-        assertThat(expectedEmd, is(actualEmd));
+        assertThat(String.format("ddm2Emd test failed for file %s", this.testName), expectedEmd, is(actualEmd));
     }
 
     private String emdElementFrom(String ddm) throws CrosswalkException, XMLSerializationException {

--- a/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/ddm/api/Ddm2EmdTest.java
@@ -68,6 +68,7 @@ import static org.apache.commons.io.FileUtils.copyFile;
 import static org.apache.commons.io.FileUtils.writeStringToFile;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeTrue;
 
@@ -94,7 +95,6 @@ public class Ddm2EmdTest {
         }
     }
 
-    @Test
     /** Proofs validity of the public examples.
      *
      * This might fail during upgrade of XSDs
@@ -103,11 +103,12 @@ public class Ddm2EmdTest {
      * NB: also eat each sword pudding (after build and deploy of easy-app/front-end/easy-sword) with:
      * 'zip -r d.zip *;curl -i --data-binary @d.zip -u easyadmin:easyadmin deasy.dans.knaw.nl/sword/deposit'
      **/
+    @Test
     public void publicExamplesAreValid() throws Exception {
         externalSchemaCheck();
         for (File file : publicExamples) {
-
             EasyMetadata emd = crosswalk.createFrom(file);
+            assertNotNull(emd);
 
             // write result
             String dir = "target/swordPuddings/" + file.getName().replace(".xml", "");
@@ -123,7 +124,6 @@ public class Ddm2EmdTest {
 
             // just a limited check of the output
             assertThat("EMD content from " + file, emdString, containsString("easy-discipline:"));
-
         }
     }
 
@@ -175,6 +175,7 @@ public class Ddm2EmdTest {
         XPath xpath = createXpathInstance();
         // Conversion
         EasyMetadata emd = crosswalk.createFrom(new File(ddmXml));
+        assertNotNull(emd);
         String emdString = new EmdMarshaller(emd).getXmlString();
         // Write the conversion result
         Files.write(Paths.get(emdXmlActual), emdString.getBytes(StandardCharsets.UTF_8));

--- a/src/test/resources/ddm2emdCrosswalk/dcxDaiAuthor.output.xml
+++ b/src/test/resources/ddm2emdCrosswalk/dcxDaiAuthor.output.xml
@@ -6,7 +6,7 @@
         <eas:creator>
             <eas:initials>X.I.</eas:initials>
             <eas:surname>lastname</eas:surname>
-            <eas:entityId eas:scheme="DAI">info:eu-repo/dai/nl/9876543216</eas:entityId>
+            <eas:entityId eas:identification-system="info:eu-repo/dai/nl/" eas:scheme="DAI">9876543216</eas:entityId>
         </eas:creator>
     </emd:creator>
     <emd:other>

--- a/src/test/resources/input/ddm-creators-organization-mixed.xml
+++ b/src/test/resources/input/ddm-creators-organization-mixed.xml
@@ -36,7 +36,7 @@
 				<dcx-dai:insertions>v.d</dcx-dai:insertions>
 				<dcx-dai:surname>Coen</dcx-dai:surname>
                 <dcx-dai:role>ContactPerson</dcx-dai:role>
-                <dcx-dai:DAI>93313935x</dcx-dai:DAI>
+                <dcx-dai:DAI>933139357</dcx-dai:DAI>
                 <dcx-dai:organization>
 					<dcx-dai:name xml:lang="en">KNAW</dcx-dai:name>
 				</dcx-dai:organization>
@@ -53,7 +53,7 @@
 				<dcx-dai:titles xml:lang="en">MSc.</dcx-dai:titles>
 				<dcx-dai:initials>E</dcx-dai:initials>
 				<dcx-dai:surname>Ind</dcx-dai:surname>
-				<dcx-dai:DAI>13313935x</dcx-dai:DAI> 
+				<dcx-dai:DAI>133139352</dcx-dai:DAI>
 			</dcx-dai:author>
 		</dcx-dai:creatorDetails>
 		<ddm:created>2013</ddm:created>

--- a/src/test/resources/input/emd-actual-expected.xml
+++ b/src/test/resources/input/emd-actual-expected.xml
@@ -27,7 +27,7 @@
             <eas:prefix>v.d</eas:prefix>
             <eas:surname>Coen</eas:surname>
             <eas:organization>KNAW</eas:organization>
-            <eas:entityId eas:scheme="DAI">93313935x</eas:entityId>
+            <eas:entityId eas:identification-system="info:eu-repo/dai/nl/" eas:scheme="DAI">933139357</eas:entityId>
             <eas:role eas:scheme="DATACITE">ContactPerson</eas:role>
         </eas:creator>
         <eas:creator>
@@ -38,7 +38,7 @@
             <eas:title>MSc.</eas:title>
             <eas:initials>E</eas:initials>
             <eas:surname>Ind</eas:surname>
-            <eas:entityId eas:scheme="DAI">13313935x</eas:entityId>
+            <eas:entityId eas:identification-system="info:eu-repo/dai/nl/" eas:scheme="DAI">133139352</eas:entityId>
         </eas:creator>
     </emd:creator>
     <emd:subject/>

--- a/src/test/resources/output/example1.xml
+++ b/src/test/resources/output/example1.xml
@@ -11,7 +11,7 @@
             <eas:prefix>van den</eas:prefix>
             <eas:surname>Aarden</eas:surname>
             <eas:organization>Utrecht University</eas:organization>
-            <eas:entityId eas:scheme="DAI">123456789</eas:entityId>
+            <eas:entityId eas:identification-system="info:eu-repo/dai/nl/" eas:scheme="DAI">123456789</eas:entityId>
             <eas:role eas:scheme="DATACITE">Distributor</eas:role>
         </eas:creator>
     </emd:creator>

--- a/src/test/resources/output/example2.xml
+++ b/src/test/resources/output/example2.xml
@@ -16,7 +16,7 @@
             <eas:prefix>van den</eas:prefix>
             <eas:surname>Aarden</eas:surname>
             <eas:organization>Utrecht University</eas:organization>
-            <eas:entityId eas:scheme="DAI">123456789</eas:entityId>
+            <eas:entityId eas:identification-system="info:eu-repo/dai/nl/" eas:scheme="DAI">123456789</eas:entityId>
         </eas:creator>
         <eas:creator>
             <eas:title>dr.</eas:title>


### PR DESCRIPTION
fixes EASY-2362

#### When applied it will
* let a DAI be parsed correctly in AuthorDetailsHandler

#### Before merging
* [x] merge https://github.com/DANS-KNAW/easy-schema-examples/pull/9
* [x] release `easy-schema-examples`
* [x] use the new version of `easy-schema-examples` in this PR

@DANS-KNAW/easy for review